### PR TITLE
Fix installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ setup(
     test_suite='tests',
     tests_require=['redis'],
     platforms='any',
+    install_requires=[
+        'click==4.0',
+        'redis==2.10.3',
+        'structlog==15.1.0'
+    ],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(
     tests_require=['redis'],
     platforms='any',
     install_requires=[
-        'click==4.0',
-        'redis==2.10.3',
-        'structlog==15.1.0'
+        'click',
+        'redis',
+        'structlog'
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Both installing from pip and cloning the repository and running
`setup.py install` both fail as a result of missing requirements. This
patch adds those requirements listed in requirements.txt to setup.py.

Tested with `python setup.py install` as well as `pip install -e ~/tasktiger`

Closes #6