### PR TITLE
Task refactor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -497,7 +497,7 @@ The ``Task`` object has the following properties:
 
 - ``func``: The imported (executable) function
 
-The ``Task`` object has the following methods.
+The ``Task`` object has the following methods:
 
 - ``cancel``: Cancel a scheduled task.
 
@@ -507,7 +507,11 @@ The ``Task`` object has the following methods.
 
 - ``execute``: Run the task without queueing it.
 
+- ``n_executions``: Queries and returns the number of past task executions.
+
 - ``retry``: Requeue the task from the error queue for execution.
+
+- ``update_scheduled_time``: Updates a scheduled task's date to the given date.
 
 Example 1: Queueing a unique task and canceling it without a reference to the
 original task.

--- a/README.rst
+++ b/README.rst
@@ -454,9 +454,8 @@ evaluate ``sys.argv`` to ensure proper argument parsing, instead of using a
 Inspect, requeue and delete tasks
 ---------------------------------
 
-TaskTiger does not currently come with an admin interface, but provides access
-to the ``Task`` class which lets you inspect queues and requeue and delete
-tasks.
+TaskTiger provides access to the ``Task`` class which lets you inspect queues
+and perform various actions on tasks.
 
 Each queue can have tasks in the following states:
 
@@ -475,6 +474,13 @@ you load tracebacks from failed task executions using the ``load_executions``
 keyword argument, which accepts an integer indicating how many executions
 should be loaded.
 
+Tasks can also be constructed and queued using the regular constructor, which
+takes the TaskTiger instance, the function name and the options described in
+the "Task options" section. The task can then be queued using its ``delay``
+method. Note that the ``when`` argument needs to be passed to the ``delay``
+method, if applicable. Unique tasks can be reconstructed using the same
+arguments.
+
 The ``Task`` object has the following properties:
 
 - ``id``: The task ID.
@@ -486,22 +492,46 @@ The ``Task`` object has the following properties:
   the worker host in ``host``, the exception name in ``exception_name`` and
   the full traceback in ``traceback``.
 
-- ``func``, ``args``, ``kwargs``: The serialized function name with all of its
-  arguments.
+- ``serialized_func``, ``args``, ``kwargs``: The serialized function name with
+  all of its arguments.
 
-The ``Task`` object has the following methods. Note that these methods only
-work for tasks that are in the error queue.
+- ``func``: The imported (executable) function
 
-- ``retry``: Requeue the task for execution.
+The ``Task`` object has the following methods.
+
+- ``cancel``: Cancel a scheduled task.
+
+- ``delay``: Queue the task for execution.
 
 - ``delete``: Remove the task from the error queue.
 
-Example:
+- ``execute``: Run the task without queueing it.
+
+- ``retry``: Requeue the task from the error queue for execution.
+
+Example 1: Queueing a unique task and canceling it without a reference to the
+original task.
 
 .. code:: python
 
-  from tasktiger import TaskTiger
-  from tasktiger.task import Task
+  from tasktiger import TaskTiger, Task
+
+  tiger = TaskTiger()
+
+  # Send an email in five minutes.
+  task = Task(tiger, send_mail, args=['email_id'], unique=True)
+  task.delay(when=datetime.timedelta(minutes=5))
+
+  # Unique tasks get back a task instance referring to the same task by simply
+  # creating the same task again.
+  task = Task(tiger, send_mail, args=['email_id'], unique=True)
+  task.cancel()
+
+Example 2: Inspecting queues and retrying a task by ID.
+
+.. code:: python
+
+  from tasktiger import TaskTiger, Task
 
   QUEUE_NAME = 'default'
   TASK_STATE = 'error'

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -1,3 +1,5 @@
+import calendar
+import datetime
 import importlib
 import hashlib
 import json
@@ -65,3 +67,13 @@ def serialize_retry_method(retry_method):
         return (serialize_func_name(retry_method), ())
     else:
         return (serialize_func_name(retry_method[0]), retry_method[1])
+
+def get_timestamp(when):
+    # convert timedelta to datetime
+    if isinstance(when, datetime.timedelta):
+        when = datetime.datetime.utcnow() + when
+
+    if when:
+        # Convert to unixtime: utctimetuple drops microseconds so we add
+        # them manually.
+        return calendar.timegm(when.utctimetuple()) + when.microsecond/1.e6

--- a/tasktiger/exceptions.py
+++ b/tasktiger/exceptions.py
@@ -31,3 +31,8 @@ class RetryException(Exception):
         self.method = method
         self.exc_info = sys.exc_info() if original_traceback else None
         self.log_error = log_error
+
+class TaskNotFound(Exception):
+    """
+    The task was not found or does not exist in the given queue/state.
+    """

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -219,6 +219,12 @@ DELETE_IF_NOT_IN_ZSETS = """
     return 0
 """
 
+# KEYS = { key }
+# ARGV = { member }
+FAIL_IF_NOT_IN_ZSET = """
+    assert(redis.call('zscore', KEYS[1], ARGV[1]), '<FAIL_IF_NOT_IN_ZSET>')
+"""
+
 class RedisScripts(object):
     def __init__(self, redis):
         self._zadd_noupdate = redis.register_script(ZADD_NOUPDATE)
@@ -237,6 +243,9 @@ class RedisScripts(object):
 
         self._delete_if_not_in_zsets = redis.register_script(
             DELETE_IF_NOT_IN_ZSETS)
+
+        self._fail_if_not_in_zset = redis.register_script(
+            FAIL_IF_NOT_IN_ZSET)
 
     def zadd(self, key, score, member, mode, client=None):
         """
@@ -361,3 +370,12 @@ class RedisScripts(object):
             keys=[key]+set_list,
             args=[member],
             client=client)
+
+    def fail_if_not_in_zset(self, key, member, client=None):
+        """
+        Fails with an error containing the string '<FAIL_IF_NOT_IN_ZSET>' if
+        the given ``member`` is not in the ZSET ``key``. This can be used in
+        a pipeline to assert that the member is in the ZSET and cancel the
+        execution otherwise.
+        """
+        self._fail_if_not_in_zset(keys=[key], args=[member], client=client)

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -165,10 +165,10 @@ class Task(object):
 
     def _move(self, from_state=None, to_state=None, when=None, mode=None):
         """
-        Internal helper to move a task from one state another (e.g. from QUEUED
-        to DELAYED). The "when" argument indicates the timestamp of the task in
-        the new state. If no to_state is specified, the task will be simply
-        removed from the original state.
+        Internal helper to move a task from one state to another (e.g. from
+        QUEUED to DELAYED). The "when" argument indicates the timestamp of the
+        task in the new state. If no to_state is specified, the task will be
+        simply removed from the original state.
 
         The "mode" param can be specified to define how the timestamp in the
         new state should be updated and is passed to the ZADD Redis script (see

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -1,30 +1,287 @@
+import calendar
 import datetime
 import json
-from ._internal import ERROR, QUEUED
+import redis
+import time
 
-# This module contains helper methods to inspect and requeue tasks from queues.
-# TODO: Use task objects wherever we can.
+from ._internal import *
+from .exceptions import TaskNotFound
+
+__all__ = ['Task']
 
 class Task(object):
-    def __init__(self, tiger, queue, state, _data, _ts=None, _executions=None):
+    def __init__(self, tiger, func=None, args=None, kwargs=None, queue=None,
+                 hard_timeout=None, unique=None, lock=None, lock_key=None,
+                 retry=None, retry_on=None, retry_method=None,
+                 _data=None, _state=None, _ts=None, _executions=None):
         """
-        Initializes a Task from the internal structure. Use tasks_from_queue to
-        retrieve tasks from a given queue. Don't call this directly.
+        Queues a task. See README.rst for an explanation of the options.
         """
+
+        if func and queue is None:
+            queue = getattr(func, '_task_queue', tiger.config['DEFAULT_QUEUE'])
+
         self.tiger = tiger
-        self.queue = queue
-        self.state = state
-        self.data = json.loads(_data)
-        if _executions:
-            self.executions = [json.loads(e) for e in _executions if e]
+        self._func = func
+        self._queue = queue
+        self._state = _state
+        self._ts = _ts
+        self._executions = _executions or []
+
+        # Internal initialization based on raw data.
+        if _data is not None:
+            self._data = _data
+            return
+
+        assert func
+
+        serialized_name = serialize_func_name(func)
+
+        if unique is None:
+            unique = getattr(func, '_task_unique', False)
+
+        if lock is None:
+            lock = getattr(func, '_task_lock', False)
+
+        if lock_key is None:
+            lock_key = getattr(func, '_task_lock_key', None)
+
+        if retry is None:
+            retry = getattr(func, '_task_retry', False)
+
+        if retry_on is None:
+            retry_on = getattr(func, '_task_retry_on', None)
+
+        if retry_method is None:
+            retry_method = getattr(func, '_task_retry_method', None)
+
+        if unique:
+            task_id = gen_unique_id(serialized_name, args, kwargs)
         else:
-            self.executions = []
-        self.id = self.data['id']
-        self.ts = _ts
-        self.func = self.data['func']
-        self.args = self.data.get('args', [])
-        self.kwargs = self.data.get('kwargs', {})
-        self.unique = self.data.get('unique', False)
+            task_id = gen_id()
+
+        task = {
+            'id': task_id,
+            'func': serialized_name,
+        }
+        if unique:
+            task['unique'] = True
+        if lock or lock_key:
+            task['lock'] = True
+            if lock_key:
+                task['lock_key'] = lock_key
+        if args:
+            task['args'] = args
+        if kwargs:
+            task['kwargs'] = kwargs
+        if hard_timeout:
+            task['hard_timeout'] = hard_timeout
+        if retry or retry_on or retry_method:
+            if not retry_method:
+                retry_method = tiger.config['DEFAULT_RETRY_METHOD']
+
+            retry_method = serialize_retry_method(retry_method)
+
+            task['retry_method'] = retry_method
+            if retry_on:
+                task['retry_on'] = [serialize_func_name(cls)
+                                    for cls in retry_on]
+
+        self._data = task
+
+    @property
+    def id(self):
+        return self._data['id']
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def queue(self):
+        return self._queue
+
+    @property
+    def serialized_func(self):
+        return self._data['func']
+
+    @property
+    def lock(self):
+        return self._data.get('lock', False)
+
+    @property
+    def lock_key(self):
+        return self._data.get('lock_key')
+
+    @property
+    def args(self):
+        return self._data.get('args', [])
+
+    @property
+    def kwargs(self):
+        return self._data.get('kwargs', {})
+
+    @property
+    def hard_timeout(self):
+        return self._data.get('hard_timeout', None)
+
+    @property
+    def unique(self):
+        return self._data.get('unique', False)
+
+    @property
+    def retry_method(self):
+        if 'retry_method' in self._data:
+            retry_func, retry_args = self._data['retry_method']
+            return retry_func, retry_args
+        else:
+            return None
+
+    @property
+    def retry_on(self):
+        return self._data.get('retry_on')
+
+    @property
+    def func(self):
+        if not self._func:
+            self._func = import_attribute(self.serialized_func)
+        return self._func
+
+    @property
+    def ts(self):
+        """
+        The timestamp (datetime) of the task in the queue, or None, if the task
+        hasn't been queued.
+        """
+        return self._ts
+
+    @property
+    def executions(self):
+        return self._executions
+
+    def _move(self, from_state=None, to_state=None, when=None, mode=None):
+        """
+        Internal helper to move a task from one state another (e.g. from QUEUED
+        to DELAYED). The "when" argument indicates the timestamp of the task in
+        the new state. If no to_state is specified, the task will be simply
+        removed from the original state.
+
+        The "mode" param can be specified to define how the timestamp in the
+        new state should be updated and is passed to the ZADD Redis script (see
+        its documentation for details).
+
+        Raises TaskNotFound if the task is not in the expected state or not in
+        the expected queue.
+        """
+
+        pipeline = self.tiger.connection.pipeline()
+        scripts = self.tiger.scripts
+        _key = self.tiger._key
+
+        from_state = from_state or self.state
+        queue = self.queue
+
+        assert from_state
+        assert queue
+
+        scripts.fail_if_not_in_zset(_key(from_state, queue), self.id,
+                                    client=pipeline)
+        if to_state:
+            if not when:
+                when = time.time()
+            if mode:
+                scripts.zadd(_key(to_state, queue), when, self.id,
+                                  mode, client=pipeline)
+            else:
+                pipeline.zadd(_key(to_state, queue), self.id, when)
+            pipeline.sadd(_key(to_state), queue)
+        pipeline.zrem(_key(from_state, queue), self.id)
+
+        if not to_state: # Remove the task if necessary
+            if self.unique:
+                # Only delete if it's not in any other queue
+                check_states = set([ACTIVE, QUEUED, ERROR, SCHEDULED])
+                check_states.remove(from_state)
+                # TODO: Do the following two in one call.
+                scripts.delete_if_not_in_zsets(_key('task', self.id, 'executions'),
+                                                    self.id, [
+                    _key(state, queue) for state in check_states
+                ], client=pipeline)
+                scripts.delete_if_not_in_zsets(_key('task', self.id),
+                                                    self.id, [
+                    _key(state, queue) for state in check_states
+                ], client=pipeline)
+            else:
+                # Safe to remove
+                pipeline.delete(_key('task', self.id, 'executions'))
+                pipeline.delete(_key('task', self.id))
+
+        scripts.srem_if_not_exists(_key(from_state), queue,
+                _key(from_state, queue), client=pipeline)
+
+        if to_state == QUEUED:
+            pipeline.publish(_key('activity'), queue)
+
+        try:
+            pipeline.execute()
+        except redis.ResponseError as e:
+            if '<FAIL_IF_NOT_IN_ZSET>' in unicode(e):
+                raise TaskNotFound('Task {} not found in queue "{}" in state "{}".'.format(
+                    self.id, queue, from_state
+                ))
+            raise
+        else:
+            self._state = to_state
+
+    def execute(self):
+        func = self.func
+        if getattr(func, '_task_batch', False):
+            return func([{'args': self.args, 'kwargs': self.kwargs}])
+        else:
+            return func(*self.args, **self.kwargs)
+
+    def delay(self, when=None):
+        tiger = self.tiger
+
+        if tiger.config['ALWAYS_EAGER'] and not \
+                (when and when.utctimetuple() >= datetime.datetime.utcnow().utctimetuple()):
+            return self.execute()
+
+        now = time.time()
+        self._data['time_last_queued'] = now
+        serialized_task = json.dumps(self._data)
+
+        # convert timedelta to datetime
+        if isinstance(when, datetime.timedelta):
+            when = datetime.datetime.utcnow() + when
+
+        # convert to unixtime
+        if isinstance(when, datetime.datetime):
+            when = calendar.timegm(when.utctimetuple()) + when.microsecond/1.e6
+
+        if when:
+            state = SCHEDULED
+        else:
+            state = QUEUED
+
+        ts = when or now
+
+        pipeline = tiger.connection.pipeline()
+        pipeline.sadd(tiger._key(state), self.queue)
+        pipeline.set(tiger._key('task', self.id), serialized_task)
+        # In case of unique tasks, don't update the score.
+        tiger.scripts.zadd(tiger._key(state, self.queue), ts, self.id,
+                          mode='nx', client=pipeline)
+        if state == QUEUED:
+            pipeline.publish(tiger._key('activity'), self.queue)
+        pipeline.execute()
+
+        self._state = state
+        self._ts = ts
 
     def __repr__(self):
         return u'<Task %s>' % self.func
@@ -41,13 +298,20 @@ class Task(object):
             pipeline = tiger.connection.pipeline()
             pipeline.get(tiger._key('task', task_id))
             pipeline.lrange(tiger._key('task', task_id, 'executions'), -load_executions, -1)
-            task, executions = pipeline.execute()
+            serialized_data, serialized_executions = pipeline.execute()
         else:
-            task = tiger.connection.get(tiger._key('task', task_id))
-            executions = []
+            serialized_data = tiger.connection.get(tiger._key('task', task_id))
+            serialized_executions = []
         # XXX: No timestamp for now
-        if task:
-            return Task(tiger, queue, state, task, None, executions)
+        if serialized_data:
+            data = json.loads(serialized_data)
+            executions = [json.loads(e) for e in serialized_executions if e]
+            return Task(tiger, queue=queue, _data=data, _state=state,
+                        _executions=executions)
+        else:
+            raise TaskNotFound('Task {} not found.'.format(
+                task_id
+            ))
 
     @classmethod
     def tasks_from_queue(self, tiger, queue, state, skip=0, limit=1000,
@@ -67,6 +331,8 @@ class Task(object):
         pipeline.zrange(key, -limit-skip, -1-skip, withscores=True)
         n, items = pipeline.execute()
 
+        tasks = []
+
         if items:
             tss = [datetime.datetime.utcfromtimestamp(item[1]) for item in items]
             if load_executions:
@@ -76,34 +342,47 @@ class Task(object):
                     pipeline.lrange(tiger._key('task', item[0], 'executions'), -load_executions, -1)
                 results = pipeline.execute()
 
-                tasks = [Task(tiger, queue, state, task, ts, executions)
-                    for task, executions, ts in zip(results[0], results[1:], tss)]
+                for serialized_data, serialized_executions, ts in zip(results[0], results[1:], tss):
+                    data = json.loads(serialized_data)
+                    executions = [json.loads(e) for e in serialized_executions if e]
+
+                    task = Task(tiger, queue=queue, _data=data, _state=state,
+                                _ts=ts, _executions=executions)
+
+                    tasks.append(task)
             else:
                 data = tiger.connection.mget([tiger._key('task', item[0]) for item in items])
-                tasks = [Task(tiger, queue, state, task, ts)
-                         for task, ts in zip(data, tss)]
-        else:
-            tasks = []
+                for serialized_data, ts in zip(data, tss):
+                    data = json.loads(serialized_data)
+                    task = Task(tiger, queue=queue, _data=data, _state=state,
+                                _ts=ts)
+                    tasks.append(task)
 
         return n, tasks
 
     def retry(self):
         """
         Retries a task that's in the error queue.
+
+        Raises TaskNotFound if the task could not be found in the ERROR
+        queue.
         """
-        assert self.state == ERROR
-        # TODO: Only allow this if the task is still in ERROR state
-        self.tiger._redis_move_task(self.queue, self.id, ERROR, QUEUED)
+        self._move(from_state=ERROR, to_state=QUEUED)
+
+    def cancel(self):
+        """
+        Cancels a task that is queued in the SCHEDULED queue.
+
+        Raises TaskNotFound if the task could not be found in the SCHEDULED
+        queue.
+        """
+        self._move(from_state=SCHEDULED)
 
     def delete(self):
         """
         Removes a task that's in the error queue.
+
+        Raises TaskNotFound if the task could not be found in the ERROR
+        queue.
         """
-        assert self.state == ERROR
-        if self.unique:
-            remove_task = 'check'
-        else:
-            remove_task = 'always'
-        # TODO: Only allow this if the task is still in ERROR state
-        self.tiger._redis_move_task(self.queue, self.id, ERROR,
-                                    remove_task=remove_task, mode='min')
+        self._move(from_state=ERROR)

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -247,10 +247,6 @@ class Task(object):
     def delay(self, when=None):
         tiger = self.tiger
 
-        if tiger.config['ALWAYS_EAGER'] and not \
-                (when and when.utctimetuple() >= datetime.datetime.utcnow().utctimetuple()):
-            return self.execute()
-
         now = time.time()
         self._data['time_last_queued'] = now
         serialized_task = json.dumps(self._data)
@@ -262,6 +258,12 @@ class Task(object):
         # convert to unixtime
         if isinstance(when, datetime.datetime):
             when = calendar.timegm(when.utctimetuple()) + when.microsecond/1.e6
+
+        # When using ALWAYS_EAGER, make sure we have serialized the task to
+        # ensure there are no serialization errors.
+        if tiger.config['ALWAYS_EAGER'] and not \
+                (when and when.utctimetuple() >= datetime.datetime.utcnow().utctimetuple()):
+            return self.execute()
 
         if when:
             state = SCHEDULED

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -195,18 +195,18 @@ class Worker(object):
                     'args': task.args,
                     'kwargs': task.kwargs,
                 } for task in tasks]
-                hard_timeout = max(task.hard_timeout for task in tasks) or \
-                               getattr(func, '_task_hard_timeout', None) or \
-                               self.config['DEFAULT_HARD_TIMEOUT']
+                hard_timeout = (max(task.hard_timeout for task in tasks) or
+                                getattr(func, '_task_hard_timeout', None) or
+                                self.config['DEFAULT_HARD_TIMEOUT'])
 
                 with UnixSignalDeathPenalty(hard_timeout):
                     func(params)
             else:
                 # Process sequentially.
                 for task in tasks:
-                    hard_timeout = task.hard_timeout or \
-                                   getattr(func, '_task_hard_timeout', None) or \
-                                   self.config['DEFAULT_HARD_TIMEOUT']
+                    hard_timeout = (task.hard_timeout or
+                                    getattr(func, '_task_hard_timeout', None) or
+                                    self.config['DEFAULT_HARD_TIMEOUT'])
 
                     with UnixSignalDeathPenalty(hard_timeout):
                         func(*task.args, **task.kwargs)
@@ -234,9 +234,8 @@ class Worker(object):
             execution['host'] = socket.gethostname()
             serialized_execution = json.dumps(execution)
             for task in tasks:
-                self.connection.rpush(
-                    self._key('task', task.id,'executions'),
-                    serialized_execution)
+                self.connection.rpush(self._key('task', task.id, 'executions'),
+                                      serialized_execution)
 
         return success
 
@@ -520,7 +519,7 @@ class Worker(object):
             log_context = {}
 
             if should_retry:
-                retry_num = self.connection.llen(self._key('task', task.id, 'executions'))
+                retry_num = task.n_executions()
                 log_context['retry_func'] = retry_func
                 log_context['retry_num'] = retry_num
 

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -431,8 +431,8 @@ class Worker(object):
                         # scheduled in case of a unique task, don't prolong
                         # the schedule date).
                         when = time.time() + self.config['LOCK_RETRY']
-                        assert task.state == ACTIVE
-                        task._move(to_state=SCHEDULED, when=when, mode='min')
+                        task._move(from_state=ACTIVE, to_state=SCHEDULED,
+                                   when=when, mode='min')
                         # Make sure to remove it from this list so we don't
                         # re-add to the ACTIVE queue by updating the heartbeat.
                         all_task_ids.remove(task.id)
@@ -470,8 +470,7 @@ class Worker(object):
                 remove_task = 'check'
             else:
                 remove_task = 'always'
-            assert task.state == ACTIVE
-            task._move()
+            task._move(from_state=ACTIVE)
             log.debug('done')
 
         if success:
@@ -556,8 +555,7 @@ class Worker(object):
             if state == ERROR and not should_log_error:
                 _mark_done()
             else:
-                assert task.state == ACTIVE
-                task._move(to_state=state, when=when)
+                task._move(from_state=ACTIVE, to_state=state, when=when)
 
     def _worker_run(self):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -646,11 +646,21 @@ class TaskTestCase(BaseTestCase):
         self.assertRaises(StandardError, task.delay)
         self._ensure_queues()
 
+        # Even when we specify "when" in the past.
+        task = Task(self.tiger, simple_task)
+        task.delay(when=datetime.timedelta(seconds=-5))
+        self._ensure_queues()
+
         # Ensure there is an exception if we can't serialize the task.
         task = Task(self.tiger, decorated_task,
                     args=[object()])
         self.assertRaises(TypeError, task.delay)
         self._ensure_queues()
+
+        # Ensure task is not executed if it's scheduled in the future.
+        task = Task(self.tiger, simple_task)
+        task.delay(when=datetime.timedelta(seconds=5))
+        self._ensure_queues(scheduled={'default': 1})
 
 
 if __name__ == '__main__':

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -633,6 +633,25 @@ class TaskTestCase(BaseTestCase):
         self.assertEqual(task0.queue, tasks[0].queue)
         self.assertEqual(task0.queue, 'default')
 
+    def test_eager(self):
+        self.tiger.config['ALWAYS_EAGER'] = True
+
+        # Ensure task is immediately executed.
+        task = Task(self.tiger, simple_task)
+        task.delay()
+        self._ensure_queues()
+
+        # Ensure task is immediately executed.
+        task = Task(self.tiger, exception_task)
+        self.assertRaises(StandardError, task.delay)
+        self._ensure_queues()
+
+        # Ensure there is an exception if we can't serialize the task.
+        task = Task(self.tiger, decorated_task,
+                    args=[datetime.datetime.utcnow()])
+        self.assertRaises(TypeError, task.delay)
+        self._ensure_queues()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -603,7 +603,7 @@ class TaskTestCase(BaseTestCase):
         task.delay(when=datetime.timedelta(minutes=5))
         self._ensure_queues(scheduled={'default': 1})
 
-        # We can look up a non-unique task by recreating it.
+        # We can look up a unique task by recreating it.
         task = Task(self.tiger, simple_task, unique=True)
         task.cancel()
         self._ensure_queues()
@@ -648,7 +648,7 @@ class TaskTestCase(BaseTestCase):
 
         # Ensure there is an exception if we can't serialize the task.
         task = Task(self.tiger, decorated_task,
-                    args=[datetime.datetime.utcnow()])
+                    args=[object()])
         self.assertRaises(TypeError, task.delay)
         self._ensure_queues()
 

--- a/tests/redis_scripts.py
+++ b/tests/redis_scripts.py
@@ -25,6 +25,10 @@ class RedisScriptsTestCase(unittest.TestCase):
         entries = self._test_zadd('nx')
         self.assertEqual(entries, [('key2', 1.0), ('key1', 2.0)])
 
+    def test_zadd_xx(self):
+        entries = self._test_zadd('xx')
+        self.assertEqual(entries, [('key1', 3.0)])
+
     def test_zadd_min(self):
         entries = self._test_zadd('min')
         self.assertEqual(entries, [('key2', 0.0), ('key1', 2.0)])


### PR DESCRIPTION
Refactored the code to make use of the Task class, which now can be used to queue new tasks as well as cancel/retry/inspect them, and is used internally as well.

Added a TaskNotFound exception which is raised when a task cannot be found or does not exist in the expected queue, so we know when e.g. canceling a scheduled task failed.

This also fixes #11.

@closeio/engineering review?