### PR TITLE
Control which queues we process via settings

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -240,7 +240,7 @@ class TaskTiger(object):
                 importlib.import_module(module_name)
                 self.log.debug('imported module', module_name=module_name)
 
-        worker = Worker(self, queues.split(','))
+        worker = Worker(self, queues.split(',') if queues else None)
         worker.run()
 
     def delay(self, func, args=None, kwargs=None, queue=None,

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -125,6 +125,18 @@ class TaskTiger(object):
 
             # How often to print stats.
             'STATS_INTERVAL': 60,
+
+            # The following settings are only considered if no explicit queues
+            # are passed in the command line (or to the queues argument in the
+            # run_worker() method).
+
+            # If non-empty, a worker only processeses the given queues.
+            'ONLY_QUEUES': [],
+
+            # TODO: not implemented
+            # The defined queues will be excluded (even if they're specified
+            # in ONLY_QUEUES).
+            #'IGNORE_QUEUES': []
         }
         if config:
             self.config.update(config)
@@ -228,7 +240,7 @@ class TaskTiger(object):
                 importlib.import_module(module_name)
                 self.log.debug('imported module', module_name=module_name)
 
-        worker = Worker(self, queues)
+        worker = Worker(self, queues.split(','))
         worker.run()
 
     def delay(self, func, args=None, kwargs=None, queue=None,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -37,7 +37,9 @@ class Worker(object):
         self.stats_thread = None
 
         if queues:
-            self.queue_filter = queues.split(',')
+            self.queue_filter = queues
+        elif self.config['ONLY_QUEUES']:
+            self.queue_filter = self.config['ONLY_QUEUES']
         else:
             self.queue_filter = None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -115,7 +115,7 @@ class TestCase(BaseTestCase):
         self.tiger.delay(simple_task, queue='c')
         self._ensure_queues(queued={'a': 1, 'b': 1, 'c': 1})
 
-        Worker(self.tiger, queues='a,b').run(once=True)
+        Worker(self.tiger, queues=['a', 'b']).run(once=True)
         self._ensure_queues(queued={'a': 0, 'b': 0, 'c': 1})
 
         Worker(self.tiger).run(once=True)
@@ -128,7 +128,7 @@ class TestCase(BaseTestCase):
         self.tiger.delay(simple_task, queue='a.b.c')
         self._ensure_queues(queued={'a': 1, 'a.b': 1, 'a.b.c': 1, 'x': 1})
 
-        Worker(self.tiger, queues='a,b').run(once=True)
+        Worker(self.tiger, queues=['a', 'b']).run(once=True)
         self._ensure_queues(queued={'a': 0, 'a.b': 0, 'a.b.c': 0, 'x': 1})
 
     def test_nested_queue_2(self):
@@ -138,7 +138,7 @@ class TestCase(BaseTestCase):
         self.tiger.delay(simple_task, queue='a.b.c')
         self._ensure_queues(queued={'a': 1, 'a.b': 1, 'a.b.c': 1, 'x': 1})
 
-        Worker(self.tiger, queues='a.b,b').run(once=True)
+        Worker(self.tiger, queues=['a.b', 'b']).run(once=True)
         self._ensure_queues(queued={'a': 1, 'a.b': 0, 'a.b.c': 0, 'x': 1})
 
     def test_task_on_other_queue(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -573,6 +573,20 @@ class TestCase(BaseTestCase):
         Worker(self.tiger).run(once=True)
         self._ensure_queues(queued={'batch': 0})
 
+    def test_only_queues(self):
+        self.tiger.delay(simple_task, queue='a')
+        self.tiger.delay(simple_task, queue='a.a')
+        self.tiger.delay(simple_task, queue='b')
+        self.tiger.delay(simple_task, queue='b.a')
+
+        self._ensure_queues(queued={'a': 1, 'a.a': 1, 'b': 1, 'b.a': 1})
+
+        self.tiger.config['ONLY_QUEUES'] = ['a']
+
+        Worker(self.tiger).run(once=True)
+
+        self._ensure_queues(queued={'b': 1, 'b.a': 1})
+
 class TaskTestCase(BaseTestCase):
     """
     Task class test cases.


### PR DESCRIPTION
@closeio/engineering What do you think about this? We can already pass in queues to the worker with the `-q` command line argument, but this would allow us to explicitly specify queues in the config, and make sure TaskTiger workers only process queues where the task code exists.