### PR TITLE
Fix exceptions in python3

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -227,7 +227,7 @@ class Worker(object):
                 execution['retry_method'] = serialize_retry_method(exc.method)
             execution['log_error'] = exc.log_error
             execution['exception_name'] = serialize_func_name(exc.__class__)
-            exc_info = exc.exc_info
+            exc_info = exc.exc_info or sys.exc_info()
         except Exception as exc:
             execution['exception_name'] = serialize_func_name(exc.__class__)
             exc_info = sys.exc_info()
@@ -236,8 +236,6 @@ class Worker(object):
 
         if not success:
             execution['time_failed'] = time.time()
-            if not exc_info:
-                exc_info = sys.exc_info()
             # Currently we only log failed task executions to Redis.
             execution['traceback'] = \
                     ''.join(traceback.format_exception(*exc_info))

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -230,6 +230,7 @@ class Worker(object):
             exc_info = exc.exc_info
         except Exception as exc:
             execution['exception_name'] = serialize_func_name(exc.__class__)
+            exc_info = sys.exc_info()
         else:
             success = True
 
@@ -239,7 +240,7 @@ class Worker(object):
                 exc_info = sys.exc_info()
             # Currently we only log failed task executions to Redis.
             execution['traceback'] = \
-                    ''.join(traceback.format_exception(*exc_info)) if exc_info != (None, None, None) else None
+                    ''.join(traceback.format_exception(*exc_info))
             execution['success'] = success
             execution['host'] = socket.gethostname()
             serialized_execution = json.dumps(execution)


### PR DESCRIPTION
It seems python3 doesn't like it when you try to get the traceback by doing `sys.exc_info()` outside the try/except block. Moving it there appears to resolve the issue.