### PR TITLE
Catch JSONDecodeError in rollbar handler

### DIFF
--- a/tasktiger/rollbar.py
+++ b/tasktiger/rollbar.py
@@ -32,7 +32,10 @@ class StructlogRollbarHandler(RollbarHandler):
         if record.levelno < self.notify_level:
             return
 
-        data = json.loads(record.msg)
+        try:
+            data = json.loads(record.msg)
+        except json.JSONDecodeError:
+            return super(StructlogRollbarHandler, self).emit(record)
 
         # Title and grouping
         data['title'] = data['fingerprint'] = self.format_title(data)


### PR DESCRIPTION
If the log message is not JSON-formatted, it is handled by the parent class.

This should normally not happen when using only TaskTiger, but it makes logging
non-structlog errors easier when using TaskTiger's rollbar handler. Besides,
error handlers should have as few ways as possible to error out.