### PR TITLE
Handle ECHILD error in os.waitpid()

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+machine:
+  services:
+    - redis
+
 test:
   override:
+    - pyenv global 2.7.12 3.4.4 3.5.2
     - tox

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     packages=[
         'tasktiger',

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -321,8 +321,8 @@ class Worker(object):
                     for lock in locks:
                         lock.renew(self.config['ACTIVE_TASK_UPDATE_TIMEOUT'])
 
-            status = not return_code
-            return status
+            success = (return_code == 0)
+            return success
 
     def _process_from_queue(self, queue):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py35
 
 [testenv]
 commands=nosetests


### PR DESCRIPTION
See the comment of a description on how it happens. We will most likely see a "encountered ECHILD while os.waitpid" error once a week or so, which will give us more insight on whether `return_code` is ever `None`.