### PR TITLE
Fix handling of "not found" error if task disappears

### DIFF
--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -101,5 +101,5 @@ def verify_current_tasks(tasks):
         conn.rpush('task_ids', *[t.id for t in tasks])
 
 @tiger.task()
-def sleep_task():
-    time.sleep(10)
+def sleep_task(delay=10):
+    time.sleep(delay)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,27 @@ from tasktiger import TaskTiger, Worker, fixed
 
 from .config import *
 
+class Patch(object):
+    """
+    Simple context manager to patch a function, e.g.:
+
+    with Patch(module, 'func_name', mocked_func):
+        module.func_name() # will use mocked_func
+    module.func_name() # will use the original function
+
+    """
+    def __init__(self, orig_obj, func_name, new_func):
+        self.orig_obj = orig_obj
+        self.func_name = func_name
+        self.new_func = new_func
+
+    def __enter__(self):
+        self.orig_func = getattr(self.orig_obj, self.func_name)
+        setattr(self.orig_obj, self.func_name, self.new_func)
+
+    def __exit__(self, *args):
+        setattr(self.orig_obj, self.func_name, self.orig_func)
+
 def get_tiger():
     """
     Sets up logging and returns a new tasktiger instance.
@@ -19,6 +40,8 @@ def get_tiger():
         # We need this 0 here so we don't pick up scheduled tasks when
         # doing a single worker run.
         'SELECT_TIMEOUT': 0,
+
+        'ACTIVE_TASK_UPDATE_TIMEOUT': 2*DELAY,
 
         'LOCK_RETRY': DELAY*2.,
 


### PR DESCRIPTION
Ensure that a task object that disappears while the task is processing is handled properly. This could happen when a worker processes a task, then hangs for a long time, causing another worker to pick up and finish the task. Then, when the original worker resumes, the task object will be gone. Make sure we log a "not found" error and move on.