### PR TITLE
Inherit JobTimeoutException and RetryException from BaseException

### DIFF
--- a/tasktiger/exceptions.py
+++ b/tasktiger/exceptions.py
@@ -5,7 +5,7 @@ class TaskImportError(ImportError):
     Raised when a task could not be imported.
     """
 
-class JobTimeoutException(Exception):
+class JobTimeoutException(BaseException):
     """
     Raised when a job takes longer to complete than the allowed maximum timeout
     value.
@@ -16,7 +16,7 @@ class StopRetry(Exception):
     Raised by a retry function to indicate that the task shouldn't be retried.
     """
 
-class RetryException(Exception):
+class RetryException(BaseException):
     """
     Alternative to retry_on for retrying a task. If raised within a task, the
     task will be retried as long as the retry method permits. The default retry

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -229,7 +229,7 @@ class Worker(object):
             execution['log_error'] = exc.log_error
             execution['exception_name'] = serialize_func_name(exc.__class__)
             exc_info = exc.exc_info or sys.exc_info()
-        except Exception as exc:
+        except (JobTimeoutException, Exception) as exc:
             execution['exception_name'] = serialize_func_name(exc.__class__)
             exc_info = sys.exc_info()
         else:


### PR DESCRIPTION
This way task code that uses `except Exception` won't catch them.