### PR TITLE
Use a more reliable way to update heartbeat while the child process is running

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -59,7 +59,7 @@ class TestCase(BaseTestCase):
     TaskTiger main test cases.
 
     Run a single test like this:
-    python -m unittest tests.TestCase.test_unique_task
+    python -m unittest tests.test_base.TestCase.test_unique_task
     """
 
     def test_simple_task(self):


### PR DESCRIPTION
The previous way had an issue where we could lose the return code of the task child process in certain rare cases.