### PR TITLE
README: fix usage of custom redis connection in python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,8 @@ decorate and queue tasks. The constructor takes the following arguments:
 
 - ``connection``
 
-  Redis connection object
+  Redis connection object. On python 3, decode_responses should be set to True to 
+  avoid encoding problems.
 
 - ``config``
 
@@ -181,7 +182,7 @@ Example:
 
   import tasktiger
   from redis import Redis
-  conn = Redis(db=1)
+  conn = Redis(db=1, decode_responses=True)
   tiger = tasktiger.TaskTiger(connection=conn, config={
       'BATCH_QUEUES': {
           # Batch up to 50 tasks that are queued in the my_batch_queue or any

--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Example:
 
   import tasktiger
   from redis import Redis
-  conn = redis.Redis(db=1)
+  conn = Redis(db=1)
   tiger = tasktiger.TaskTiger(connection=conn, config={
       'BATCH_QUEUES': {
           # Batch up to 50 tasks that are queued in the my_batch_queue or any


### PR DESCRIPTION
redis.py [docs](https://github.com/andymccurdy/redis-py) state: 

> If the client's decode_responses flag is set the False (the default), the 'channel', 'pattern' and 'data' values in message dictionaries will be byte strings (str on Python 2, bytes on Python 3).

tasktiger seems to assume for what I think is compatibility reasons, that redis-py returns plain strings. This PR makes that explicit in the README.