### PR TITLE
Refactor to use get_message for queue_set updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click==4.0
-redis==2.10.3
+redis==2.10.5
 structlog==15.1.0


### PR DESCRIPTION
The existing logic would not process all pending messages.  This change should ensure between each run we have an up to date set of queues.