### PR TITLE
Only requeue expired tasks that are retriable on JobTimeoutException

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -106,13 +106,18 @@ class TaskTiger(object):
             'DEFAULT_HARD_TIMEOUT': 300,
 
             # The timer specifies how often the worker updates the task's
-            # timestamp in the active queue. Tasks exceeding the timeout value
-            # are requeued. Note that no delay is necessary before the retry
-            # since this condition happens when the worker crashes, and not
-            # when there is an exception in the task itself.
+            # timestamp in the active queue (in seconds). Tasks exceeding the
+            # timeout value are requeued periodically. This may happen when a
+            # worker crashes or is killed.
             'ACTIVE_TASK_UPDATE_TIMER': 10,
             'ACTIVE_TASK_UPDATE_TIMEOUT': 60,
-            'ACTIVE_TASK_EXPIRED_BATCH_SIZE': 10,
+
+            # How often we requeue expired tasks (in seconds), and how many
+            # expired tasks we requeue at a time. The interval also determines
+            # the lock timeout, i.e. it should be large enough to have enough
+            # time to requeue a batch of tasks.
+            'REQUEUE_EXPIRED_TASKS_INTERVAL': 30,
+            'REQUEUE_EXPIRED_TASKS_BATCH_SIZE': 10,
 
             # Set up queues that will be processed in batch, i.e. multiple jobs
             # are taken out of the queue at the same time and passed as a list

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -148,7 +148,7 @@ class Task(object):
         """
         Whether this task should be retried when the given exception occurs.
         """
-        for n in self.retry_on:
+        for n in (self.retry_on or []):
             if issubclass(exception_class, import_attribute(n)):
                 return True
         return False

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -144,6 +144,15 @@ class Task(object):
     def retry_on(self):
         return self._data.get('retry_on')
 
+    def should_retry_on(self, exception_class):
+        """
+        Whether this task should be retried when the given exception occurs.
+        """
+        for n in self.retry_on:
+            if issubclass(exception_class, import_attribute(n)):
+                return True
+        return False
+
     @property
     def func(self):
         if not self._func:

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -206,8 +206,9 @@ class Worker(object):
                                 _data={'id': task_id}, _state=ACTIVE)
                     task._move()
 
-        # Keep requeueing if we've exhausted our batch size, otherwise
-        # don't release the lock -- it will expire automatically.
+        # Release the lock immediately if we processed a full batch. This way,
+        # another process will be able to pick up another batch immediately
+        # without waiting for the lock to time out.
         if len(task_data) == self.config['REQUEUE_EXPIRED_TASKS_BATCH_SIZE']:
             lock.release()
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -115,6 +115,6 @@ def verify_current_tasks(tasks):
         conn.rpush('task_ids', *[t.id for t in tasks])
 
 
-@tiger.task(retry_on=[JobTimeoutException])
+@tiger.task()
 def sleep_task(delay=10):
     time.sleep(delay)

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -3,7 +3,7 @@ import time
 
 import redis
 
-from tasktiger import RetryException
+from tasktiger import JobTimeoutException, RetryException
 from tasktiger.retry import fixed
 
 from .config import DELAY, TEST_DB
@@ -115,6 +115,6 @@ def verify_current_tasks(tasks):
         conn.rpush('task_ids', *[t.id for t in tasks])
 
 
-@tiger.task()
+@tiger.task(retry_on=[JobTimeoutException])
 def sleep_task(delay=10):
     time.sleep(delay)

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -3,7 +3,7 @@ import time
 
 import redis
 
-from tasktiger import JobTimeoutException, RetryException
+from tasktiger import RetryException
 from tasktiger.retry import fixed
 
 from .config import DELAY, TEST_DB

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -790,7 +790,8 @@ class ReliabilityTestCase(BaseTestCase):
     def _test_expired_task(self, task, expected_state):
         """
         Ensure the given task ends up in the expected state if the worker is
-        killed prematurely.
+        killed prematurely. The task needs to run for longer than DELAY for
+        this test to work.
         """
         task.delay()
         self._ensure_queues(queued={'default': 1})
@@ -805,6 +806,7 @@ class ReliabilityTestCase(BaseTestCase):
 
         self._ensure_queues(active={'default': 1})
 
+        # Wait for (at least) ACTIVE_TASK_UPDATE_TIMEOUT
         time.sleep(2 * DELAY)
 
         Worker(self.tiger).run(once=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,13 +45,15 @@ def get_tiger():
 
         'ACTIVE_TASK_UPDATE_TIMEOUT': 2 * DELAY,
 
+        'REQUEUE_EXPIRED_TASKS_INTERVAL': DELAY,
+
         'LOCK_RETRY': DELAY * 2.,
 
         'DEFAULT_RETRY_METHOD': fixed(DELAY, 2),
 
         'BATCH_QUEUES': {
             'batch': 3,
-        }
+        },
     })
     tiger.log.setLevel(logging.CRITICAL)
     return tiger


### PR DESCRIPTION
This prevents retrying tasks that are not idempotent in case the worker crashes. We now also do the requeueing periodically using a lock and are more efficient about it (no per-queue round trip to Redis since finding expired tasks is now handled in a Lua script).

- [x] Unit tests that illustrate the new behavior.

@closeio/engineering feel free to review