### PR TITLE
Free up Redis connection after running worker

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -762,4 +762,6 @@ class Worker(object):
                 self.stats_thread.stop()
                 self.stats_thread = None
 
+            # Free up Redis connection
+            self._pubsub.reset()
             self.log.info('done')


### PR DESCRIPTION
This prevents leaking connections when running the worker multiple times in a row (e.g. in tests).