### PR TITLE
Fix eager queueing of scheduled tasks

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -264,10 +264,10 @@ class Task(object):
     def delay(self, when=None):
         tiger = self.tiger
 
+        ts = get_timestamp(when)
+
         now = time.time()
         self._data['time_last_queued'] = now
-
-        ts = get_timestamp(when)
 
         if not ts or ts <= now:
             # Immediately queue if the timestamp is in the past.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -734,9 +734,14 @@ class TaskTestCase(BaseTestCase):
         pytest.raises(Exception, task.delay)
         self._ensure_queues()
 
-        # Even when we specify "when" in the past.
+        # Even when we specify "when" in the past
         task = Task(self.tiger, simple_task)
         task.delay(when=datetime.timedelta(seconds=-5))
+        self._ensure_queues()
+
+        # or with a zero timedelta.
+        task = Task(self.tiger, simple_task)
+        task.delay(when=datetime.timedelta(seconds=0))
         self._ensure_queues()
 
         # Ensure there is an exception if we can't serialize the task.


### PR DESCRIPTION
When queueing a task with when=0, we should immediately execute the task. This wasn't previously the case because of the way the date was calculated.

Executing `get_timestamp(when)` *after* calculating `now` fixes this.

- [x] Add test