### PR TITLE
fix: worker process not exit as stats thread is running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 dist/
 *.egg-info/
 .tox/
+.env/
+.idea/

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -771,20 +771,20 @@ class Worker(object):
             self.stats_thread = StatsThread(self)
             self.stats_thread.start()
 
-        # Queue any periodic tasks that are not queued yet.
-        self._queue_periodic_tasks()
-
-        # First scan all the available queues for new items until they're empty.
-        # Then, listen to the activity channel.
-        # XXX: This can get inefficient when having lots of queues.
-
-        self._pubsub = self.connection.pubsub()
-        self._pubsub.subscribe(self._key('activity'))
-
-        self._queue_set = set(self._filter_queues(
-                self.connection.smembers(self._key(QUEUED))))
-
         try:
+            # Queue any periodic tasks that are not queued yet.
+            self._queue_periodic_tasks()
+
+            # First scan all the available queues for new items until they're empty.
+            # Then, listen to the activity channel.
+            # XXX: This can get inefficient when having lots of queues.
+
+            self._pubsub = self.connection.pubsub()
+            self._pubsub.subscribe(self._key('activity'))
+
+            self._queue_set = set(self._filter_queues(
+                    self.connection.smembers(self._key(QUEUED))))
+
             while True:
                 # Update the queue set on every iteration so we don't get stuck
                 # on processing a specific queue.


### PR DESCRIPTION
Enabled stats (default set `STATS_INTERVAL` to 60), a stats thread is running before connect to `redis`, if connects to `reids` is failed, `worker` main thread will exit, but stats thread is running, this behavior results unexpected `worker` process status.

I use `supervisord` to manage `worker` processes, after I stopped queue redis, all `workers` stops working, but `worker`s process status are running, because stats threads work fine.