### PR TITLE
Run tests on Python 3.6.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,5 @@ machine:
 
 test:
   override:
-    - pyenv global 2.7.12 3.4.4 3.5.2
+    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
     - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 commands=pytest {posargs}


### PR DESCRIPTION
This change runs tests on Python 3.6 to commit to support 3.6 going forward.