### PR TITLE
Support task.delay(when=...) on decorated functions

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -239,7 +239,7 @@ class TaskTiger(object):
 
         def _delay(func):
             def _delay_inner(*args, **kwargs):
-                return self.delay(func, args=args, kwargs=kwargs)
+                return self.delay(func, when=kwargs.pop('when', None), args=args, kwargs=kwargs)
             return _delay_inner
 
         # Periodic tasks are unique.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -168,6 +168,23 @@ class TestCase(BaseTestCase):
         Worker(self.tiger).run(once=True)
         self._ensure_queues(queued={'other': 0})
 
+    def test_when_decorated(self):
+        decorated_task.delay(when=datetime.timedelta(seconds=DELAY))
+        self._ensure_queues(queued={'default': 0}, scheduled={'default': 1})
+
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(queued={'default': 0}, scheduled={'default': 1})
+
+        time.sleep(DELAY)
+
+        # Two runs: The first one picks the task up from the "scheduled" queue,
+        # the second one processes it.
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(queued={'default': 1}, scheduled={'default': 0})
+
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(queued={'default': 0}, scheduled={'default': 0})
+
     def test_when(self):
         self.tiger.delay(simple_task, when=datetime.timedelta(seconds=DELAY))
         self._ensure_queues(queued={'default': 0}, scheduled={'default': 1})


### PR DESCRIPTION
Support `task.delay(when=datetime.timedelta(seconds=1))`.