### PR TITLE
fix: executing lua script error since lua script is not loaded

### DIFF
--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -476,6 +476,10 @@ class RedisScripts(object):
             for args, options in stack:
                 script_args += [len(args)-1] + list(args)
 
+            # Load scripts before executing
+            if pipeline.scripts:
+                pipeline.load_scripts()
+
             # Run the pipeline
             raw_results = self._execute_pipeline(args=script_args,
                                                  client=client)


### PR DESCRIPTION
Since latested python redis client [changed lua script loading mechanism](https://github.com/andymccurdy/redis-py/commit/94975d310353a656fb12fd68cdd2f2a4ca5ae502), library pipeline will load scripts before execution, tasktiger needs load these scripts manually