### PR TITLE
Fix load_executions in task_from_queue with custom redis prefix

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -374,7 +374,7 @@ class Task(object):
             tss = [datetime.datetime.utcfromtimestamp(item[1]) for item in items]
             if load_executions:
                 pipeline = tiger.connection.pipeline()
-                pipeline.mget(['t:task:%s' % item[0] for item in items])
+                pipeline.mget([tiger._key('task', item[0]) for item in items])
                 for item in items:
                     pipeline.lrange(tiger._key('task', item[0], 'executions'), -load_executions, -1)
                 results = pipeline.execute()


### PR DESCRIPTION
When loading executions with tasks, a hard coded redis prefix (t:) is used, meaning with a custom redis prefix, the function will crash. This patch will use the `_key` helper function to use the configured custom redis prefix.