### PR TITLE
Set json encoder/decoder via config

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -2,6 +2,7 @@ import click
 from collections import defaultdict
 import importlib
 import logging
+from json import JSONDecoder, JSONEncoder
 import redis
 import structlog
 
@@ -159,6 +160,13 @@ class TaskTiger(object):
 
             # If non-empty, a worker excludes the given queues from processing.
             'EXCLUDE_QUEUES': [],
+
+            # Serializer / Deserilaizer to use for serializing/deserializing tasks
+
+            'JSON_ENCODER': JSONEncoder,
+
+            'JSON_DECODER': JSONDecoder
+
         }
         if config:
             self.config.update(config)

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -53,7 +53,7 @@ def gen_id():
     """
     return binascii.b2a_hex(os.urandom(32)).decode('utf8')
 
-def gen_unique_id(serialized_name, args, kwargs):
+def gen_unique_id(serialized_name, args, kwargs, cls=None):
     """
     Generates and returns a hex-encoded 256-bit ID for the given task name and
     args. Used to generate IDs for unique tasks or for task locks.
@@ -62,7 +62,7 @@ def gen_unique_id(serialized_name, args, kwargs):
         'func': serialized_name,
         'args': args,
         'kwargs': kwargs,
-    }, sort_keys=True).encode('utf8')).hexdigest()
+    }, sort_keys=True, cls=cls).encode('utf8')).hexdigest()
 
 def serialize_func_name(func):
     """


### PR DESCRIPTION
Allows for custom serialization/deserialization and defaults to the built json encoder/decoder.  This also sets the encoder/decoder for all places `json.dump(s)` and `json.load(s)` is used (i.e. `gen_unique_id`).

This allows you to use a custom encoder/decoder and still use `unique=True` on tasks.

TODO: add tests, and docs