### PR TITLE
Fix pipeline script execution

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,22 @@ machine:
   services:
     - redis
 
+# From https://discuss.circleci.com/t/how-to-run-redis-3-2/5815/5
+dependencies:
+  pre:
+    - sudo service redis-server stop
+    - >
+      cd ~ && if [ ! -d "redis-4.0.6" ]; then
+        wget http://download.redis.io/releases/redis-4.0.6.tar.gz
+        tar xzf redis-4.0.6.tar.gz
+        cd redis-4.0.6 && make;
+      fi
+    - cd ~/redis-4.0.6 && sudo make install
+    - sudo sed -i 's/bin/local\/bin/g' /etc/init/redis-server.conf
+    - sudo service redis-server start
+  cache_directories:
+    - ~/redis-4.0.6
+
 test:
   override:
     - pyenv global 2.7.12 3.4.4 3.5.2 3.6.2

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -163,9 +163,6 @@ class TaskTiger(object):
         if config:
             self.config.update(config)
 
-        self.connection = connection or redis.Redis(decode_responses=True)
-        self.scripts = RedisScripts(self.connection)
-
         if setup_structlog:
             structlog.configure(
                 processors=[
@@ -192,6 +189,9 @@ class TaskTiger(object):
 
         # List of task functions that are executed periodically.
         self.periodic_task_funcs = {}
+
+        self.connection = connection or redis.Redis(decode_responses=True)
+        self.scripts = RedisScripts(self.connection)
 
     def _get_current_task(self):
         if g['current_tasks'] is None:

--- a/tasktiger/lua/execute_pipeline.lua
+++ b/tasktiger/lua/execute_pipeline.lua
@@ -5,7 +5,7 @@
 -- registered Redis Lua scripts using EVALSHA.
 --
 -- KEYS = { }
--- ARGV = { n_commands
+-- ARGV = { can_replicate_commands, n_commands
 --          [, cmd_1_n_args, cmd_1_name, [cmd_1_arg_1 , ..., cmd_1_arg_n]
 --            [, ...
 --              [, cmd_n_n_args, cmd_n_name, [cmd_n_arg_1 ..., cmd_1_arg_n]]]]}
@@ -13,10 +13,16 @@
 -- Example: ARGV = { 2, 1, "GET", "key", 0, "INFO" }
 
 local argv = ARGV
-local n_cmds = argv[1]
-local cmd_ptr = 2
+local can_replicate_commands = argv[1]
+local n_cmds = argv[2]
+local cmd_ptr = 3
 local n_args
 local results = {}
+
+if can_replicate_commands == '1' then
+    redis.replicate_commands()
+end
+
 
 -- Returns a subrange of the given table, from (and including) the first
 -- index, to (and including) the last index.

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -297,16 +297,18 @@ class RedisScripts(object):
 
         self._execute_pipeline = self.register_script_from_file('lua/execute_pipeline.lua')
 
-        self.can_replicate_commands = self._can_replicate_commands()
-
-    def _can_replicate_commands(self):
+    @property
+    def can_replicate_commands(self):
         """
         Whether Redis supports single command replication.
         """
-        info = self.redis.info('server')
-        version_info = info['redis_version'].split('.')
-        major, minor = int(version_info[0]), int(version_info[1])
-        return major > 3 or major == 3 and minor >= 2
+        if not hasattr(self, '_can_replicate_commands'):
+            info = self.redis.info('server')
+            version_info = info['redis_version'].split('.')
+            major, minor = int(version_info[0]), int(version_info[1])
+            result = major > 3 or major == 3 and minor >= 2
+            self._can_replicate_commands = result
+        return self._can_replicate_commands
 
     def register_script_from_file(self, filename):
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -450,7 +450,7 @@ class RedisScripts(object):
         # [queue1, task1, queue2, task2] -> [(queue1, task1), (queue2, task2)]
         return list(zip(result[::2], result[1::2]))
 
-    def execute_pipeline(self, pipeline, client=None):
+    def execute_pipeline(self, pipeline):
         """
         Executes the given Redis pipeline as a Lua script. When an error
         occurs, the transaction stops executing, and an exception is raised.
@@ -469,20 +469,26 @@ class RedisScripts(object):
         results = redis_scripts.execute_pipeline(p)
         """
 
+        executing_pipeline = None
         try:
+            executing_pipeline = self.redis.pipeline()
+
+            # Load scripts
+            executing_pipeline.script_load(self._execute_pipeline.script)
+            for s in pipeline.scripts:
+                executing_pipeline.script_load(s.script)
+
             # Prepare args
             stack = pipeline.command_stack
             script_args = [len(stack)]
             for args, options in stack:
                 script_args += [len(args)-1] + list(args)
 
-            # Make sure scripts exist
-            if pipeline.scripts:
-                pipeline.load_scripts()
+            # Run actual pipeline lua script
+            self._execute_pipeline(args=script_args, client=executing_pipeline)
 
-            # Run the pipeline
-            raw_results = self._execute_pipeline(args=script_args,
-                                                 client=client)
+            # Run the pipeline: always load all scripts and run actual pipeline lua script
+            raw_results = executing_pipeline.execute()[-1]
 
             # Run response callbacks on results.
             results = []
@@ -497,4 +503,6 @@ class RedisScripts(object):
             return results
 
         finally:
+            if executing_pipeline:
+                executing_pipeline.reset()
             pipeline.reset()

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -450,7 +450,7 @@ class RedisScripts(object):
         # [queue1, task1, queue2, task2] -> [(queue1, task1), (queue2, task2)]
         return list(zip(result[::2], result[1::2]))
 
-    def execute_pipeline(self, pipeline):
+    def execute_pipeline(self, pipeline, client=None):
         """
         Executes the given Redis pipeline as a Lua script. When an error
         occurs, the transaction stops executing, and an exception is raised.
@@ -471,10 +471,9 @@ class RedisScripts(object):
 
         executing_pipeline = None
         try:
-            executing_pipeline = self.redis.pipeline()
+            executing_pipeline = (client or self.redis).pipeline()
 
             # Load scripts
-            executing_pipeline.script_load(self._execute_pipeline.script)
             for s in pipeline.scripts:
                 executing_pipeline.script_load(s.script)
 

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -908,6 +908,11 @@ class Worker(object):
                                exclude_queues=sorted(self.exclude_queues),
                                single_worker_queues=sorted(self.single_worker_queues))
 
+        if not self.scripts.can_replicate_commands:
+            # Older Redis versions may create additional overhead when
+            # executing pipelines.
+            self.log.warn('using old Redis version')
+
         if self.config['STATS_INTERVAL']:
             self.stats_thread = StatsThread(self)
             self.stats_thread.start()

--- a/tests/test_redis_scripts.py
+++ b/tests/test_redis_scripts.py
@@ -300,8 +300,34 @@ class TestRedisScripts:
     def test_execute_pipeline_2(self):
         p = self.conn.pipeline()
         p.set('x', 1)
+        # Test that invalid operation halts pipeline.
         p.lrange('x', 0, -1)
         p.set('y', 1)
         pytest.raises(redis.ResponseError, self.scripts.execute_pipeline, p)
         assert self.conn.get('x') == '1'
         assert self.conn.get('y') is None
+
+    @pytest.mark.parametrize('can_replicate_commands', [True, False])
+    def test_execute_pipeline_script(self, can_replicate_commands):
+        if not self.scripts._can_replicate_commands():
+            assert False, 'test suite needs Redis 3.2 or higher'
+
+        self.scripts.can_replicate_commands = can_replicate_commands
+
+        self.conn.script_flush()
+
+        s = self.conn.register_script("redis.call('set', 'x', 'y')")
+
+        # Uncached execution
+        p = self.conn.pipeline()
+        s(client=p)
+        self.scripts.execute_pipeline(p)
+        assert self.conn.get('x') == 'y'
+
+        self.conn.delete('x')
+
+        # Cached execution
+        p = self.conn.pipeline()
+        s(client=p)
+        self.scripts.execute_pipeline(p)
+        assert self.conn.get('x') == 'y'

--- a/tests/test_redis_scripts.py
+++ b/tests/test_redis_scripts.py
@@ -309,10 +309,10 @@ class TestRedisScripts:
 
     @pytest.mark.parametrize('can_replicate_commands', [True, False])
     def test_execute_pipeline_script(self, can_replicate_commands):
-        if not self.scripts._can_replicate_commands():
+        if not self.scripts.can_replicate_commands:
             assert False, 'test suite needs Redis 3.2 or higher'
 
-        self.scripts.can_replicate_commands = can_replicate_commands
+        self.scripts._can_replicate_commands = can_replicate_commands
 
         self.conn.script_flush()
 


### PR DESCRIPTION
Supersedes https://github.com/closeio/tasktiger/pull/88 / https://github.com/closeio/tasktiger/pull/98
Fixes https://github.com/closeio/tasktiger/issues/78

For Redis 3.2 and higher, this uses single command replication, which should benefits most pipeline executions and avoids replication issues where scripts referenced in pipelines aren't replicated properly (since now only the resulting commands are replicated).

For older Redis versions, all scripts are loaded in a real Redis pipeline, which causes Redis to always replicate the "SCRIPT LOAD" commands. The downside is that the content of any referenced scripts is sent with every pipeline execution.

Tests require (at least) Redis 3.2.