### PR TITLE
Handle retry_on failures

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -146,13 +146,18 @@ class Task(object):
     def retry_on(self):
         return self._data.get('retry_on')
 
-    def should_retry_on(self, exception_class):
+    def should_retry_on(self, exception_class, logger=None):
         """
         Whether this task should be retried when the given exception occurs.
         """
         for n in (self.retry_on or []):
-            if issubclass(exception_class, import_attribute(n)):
-                return True
+            try:
+                if issubclass(exception_class, import_attribute(n)):
+                    return True
+            except TaskImportError:
+                if logger:
+                    logger.error('should_retry_on could not import class',
+                                 exception_name=n)
         return False
 
     @property

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -220,7 +220,7 @@ class Worker(object):
             self._did_work = True
             try:
                 task = Task.from_id(self.tiger, queue, ACTIVE, task_id)
-                if task.should_retry_on(JobTimeoutException):
+                if task.should_retry_on(JobTimeoutException, logger=self.log):
                     self.log.info('queueing expired task',
                                   queue=queue, task_id=task_id)
 
@@ -762,7 +762,7 @@ class Worker(object):
                             log.error('could not import exception',
                                       exception_name=exception_name)
                         else:
-                            if task.should_retry_on(exception_class):
+                            if task.should_retry_on(exception_class, logger=log):
                                 should_retry = True
                 else:
                     should_retry = True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -396,6 +396,21 @@ class TestCase(BaseTestCase):
                             scheduled={'default': 1},
                             error={'default': 0})
 
+    def test_retry_on_invalid(self):
+        """
+        Ensure we handle exceptions that can't be imported.
+        """
+        class CustomException(Exception):
+            """
+            Since this is an inline exception, it's not possible to import it
+            via dotted path.
+            """
+        self.tiger.delay(exception_task, retry_on=[CustomException])
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(queued={'default': 0},
+                            scheduled={'default': 0},
+                            error={'default': 1})
+
     def test_retry_method(self):
         task = self.tiger.delay(exception_task,
                                 retry_method=linear(DELAY, DELAY, 3))


### PR DESCRIPTION
Rather than crashing the worker, we mark the task as failed.