### PR TITLE
Rename queue lock Redis key to qslock

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -68,7 +68,8 @@ Queue periodic tasks lock
 STRING <prefix>:queue_periodic_tasks_lock
 
 Queue locks scored by timeout
-ZSET <prefix>:qlock:<queue>
+ZSET <prefix>:qslock:<queue>
+STRING <prefix>:qlock:<queue> (Legacy queue locks that are no longer used)
 """
 
 SYSTEM_LOCK_ID = 'SYSTEM_LOCK'

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -23,7 +23,7 @@ from .stats import StatsThread
 from .task import Task
 from .timeouts import UnixSignalDeathPenalty, JobTimeoutException
 
-LOCK_REDIS_KEY = 'qlock'
+LOCK_REDIS_KEY = 'qslock'
 
 __all__ = ['Worker']
 


### PR DESCRIPTION
The new semaphore lock Lua script expects the queue lock key to be a zset. Old locks were strings so they are incompatible with the new locking strategy. Using a new key name will ensure a smooth migration from old to new locks.

Related to https://github.com/closeio/tasktiger/issues/53