### PR TITLE
Refactor system lock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -673,6 +673,16 @@ executed.
           print(task.n_executions())
 
 
+Pause queue processing
+----------------------
+
+The ``--max-workers-per-queue`` option uses queue locks to control the
+number of workers that can simultaneously process the same queue. When using
+this option a system lock can be placed on a queue which will keep workers
+from processing tasks from that queue until it expires. Use the
+``set_queue_system_lock()`` method of the TaskTiger object to set this lock.
+
+
 Rollbar error handling
 ----------------------
 

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -6,6 +6,7 @@ import redis
 import time
 import structlog
 
+from .redis_semaphore import Semaphore
 from .redis_scripts import RedisScripts
 
 from ._internal import *
@@ -70,8 +71,6 @@ STRING <prefix>:queue_periodic_tasks_lock
 Queue locks scored by timeout
 ZSET <prefix>:qlock:<queue>
 """
-
-SYSTEM_LOCK_ID = 'SYSTEM_LOCK'
 
 
 class TaskTiger(object):
@@ -360,11 +359,11 @@ class TaskTiger(object):
         """
         Get system lock timeout
 
-        Returns timeout of system lock or None if lock does not exist
+        Returns time system lock expires or None if lock does not exist
         """
 
         key = self._key(LOCK_REDIS_KEY, queue)
-        return self.connection.zscore(key, SYSTEM_LOCK_ID)
+        return Semaphore.get_system_lock(self.connection, key)
 
     def set_queue_system_lock(self, queue, timeout):
         """
@@ -380,10 +379,7 @@ class TaskTiger(object):
         """
 
         key = self._key(LOCK_REDIS_KEY, queue)
-        pipeline = self.connection.pipeline()
-        pipeline.zadd(key, SYSTEM_LOCK_ID, time.time()+timeout)
-        pipeline.expire(key, timeout + 10)  # timeout plus buffer for troubleshooting
-        pipeline.execute()
+        Semaphore.set_system_lock(self.connection, key, timeout)
 
     def get_queue_stats(self):
         """

--- a/tasktiger/lua/semaphore.lua
+++ b/tasktiger/lua/semaphore.lua
@@ -25,7 +25,7 @@ local timeout = tonumber(ARGV[3])
 local now = tonumber(ARGV[4])
 
 --Remove expired locks
-redis.call("ZREMRANGEBYSCORE", semaphore_key, 0, now - timeout)
+redis.call("ZREMRANGEBYSCORE", semaphore_key, 0, now)
 
 --Check if there is a system lock which will override all other locks
 if redis.call("ZSCORE", semaphore_key, "SYSTEM_LOCK") ~= false then
@@ -54,6 +54,7 @@ if lock_count > semaphore_size then
   return {false, current_lock_count}
 else
   -- This also handles renewing an existing lock
-  redis.call("ZADD", semaphore_key, now, lock_id)
+  -- Score is set to the time this lock expires
+  redis.call("ZADD", semaphore_key, now + timeout, lock_id)
   return {true, lock_count}
 end

--- a/tasktiger/redis_semaphore.py
+++ b/tasktiger/redis_semaphore.py
@@ -3,27 +3,86 @@
 import os
 import time
 
+SYSTEM_LOCK_ID = 'SYSTEM_LOCK'
+
+
 class Semaphore(object):
-    def __init__(self, redis, name, id, timeout, max=1):
+    """Semaphore lock using Redis ZSET."""
+    def __init__(self, redis, name, lock_id, timeout, max_locks=1):
+        """
+        Semaphore lock.
+
+        Semaphore logic is implemented in the lua/semaphore.lua script.
+        Individual locks within the semaphore are managed inside a ZSET
+        using scores to track when they expire.
+
+        Arguments:
+            redis: Redis client
+            name: Name of lock. Used as ZSET key.
+            lock_id: Lock ID
+            timeout: Timeout in seconds
+            max_locks: Maximum number of locks allowed for this semaphore
+        """
+
         self.redis = redis
         self.name = name
-        self.id = id
-        self.max = max
+        self.lock_id = lock_id
+        self.max_locks = max_locks
         self.timeout = timeout
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                'lua/semaphore.lua')) as f:
             self._semaphore = self.redis.register_script(f.read())
 
+    @classmethod
+    def get_system_lock(cls, redis, name):
+        """
+        Get system lock timeout for the semaphore.
+
+        Arguments:
+            redis: Redis client
+            name: Name of lock. Used as ZSET key.
+
+        Returns: Time system lock expires or None if lock does not exist
+        """
+
+        return redis.zscore(name, SYSTEM_LOCK_ID)
+
+    @classmethod
+    def set_system_lock(cls, redis, name, timeout):
+        """
+        Set system lock for the semaphore.
+
+        Sets a system lock that will expire in timeout seconds. This
+        overrides all other locks. Existing locks cannot be renewed
+        and no new locks will be permitted until the system lock
+        expires.
+
+        Arguments:
+            redis: Redis client
+            name: Name of lock. Used as ZSET key.
+            timeout: Timeout in seconds for system lock
+        """
+
+        pipeline = redis.pipeline()
+        pipeline.zadd(name, SYSTEM_LOCK_ID, time.time() + timeout)
+        pipeline.expire(name, timeout + 10)  # timeout plus buffer for troubleshooting
+        pipeline.execute()
+
     def release(self):
         """Release semaphore."""
 
-        self.redis.zrem(self.name, self.id)
+        self.redis.zrem(self.name, self.lock_id)
 
     def acquire(self):
-        """Obtain a semaphore lock."""
+        """
+        Obtain a semaphore lock.
+
+        Returns: Tuple that contains True/False if the lock was acquired and number of
+                 locks in semaphore.
+        """
 
         acquired, locks = self._semaphore(keys=[self.name],
-                                          args=[self.id, self.max,
+                                          args=[self.lock_id, self.max_locks,
                                                 self.timeout, time.time()])
 
         # Convert Lua boolean returns to Python booleans

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -379,7 +379,7 @@ class Worker(object):
         if max_workers:
             queue_lock = Semaphore(self.connection,
                                    self._key(LOCK_REDIS_KEY, queue),
-                                   self.id, max=max_workers,
+                                   self.id, max_locks=max_workers,
                                    timeout=self.config['ACTIVE_TASK_UPDATE_TIMEOUT'])
             acquired, locks = queue_lock.acquire()
             if not acquired:

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -116,14 +116,15 @@ class TestMaxWorkers(BaseTestCase):
             lock_timeout = self.tiger.get_queue_system_lock('a')
             assert lock_timeout == time.time() + 10
 
-        with FreezeTime(datetime.datetime(2014, 1, 1, 0, 0, 10)):
+        # Confirm tasks don't get processed within the system lock timeout
+        with FreezeTime(datetime.datetime(2014, 1, 1, 0, 0, 9)):
             worker = Worker(self.tiger)
             worker.max_workers_per_queue = 2
             worker.run(once=True, force_once=True)
             self._ensure_queues(queued={'a': 2})
 
-        # 11 seconds in the future the lock should have expired
-        with FreezeTime(datetime.datetime(2014, 1, 1, 0, 0, 11)):
+        # 10 seconds in the future the lock should have expired
+        with FreezeTime(datetime.datetime(2014, 1, 1, 0, 0, 10)):
             worker = Worker(self.tiger)
             worker.max_workers_per_queue = 2
             worker.run(once=True, force_once=True)


### PR DESCRIPTION
* Moved system lock logic into Semaphore class
* Changes zset score to be the time the lock expires versus when it was acquired. Will merge https://github.com/closeio/tasktiger/pull/124/files with this change so there aren't any backwards compatibility issues.
* Don't use `max` and `id` as variable names
* Add more docs