### PR TITLE
Limit execution histories and structlog processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 dist/
 *.egg-info/
 .tox/
+.idea/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -504,6 +504,10 @@ Workers support the following options:
 
   Maximum number of workers that are allowed to process a queue.
 
+- ``--store-tracebacks/--no-store-tracebacks``
+
+  Store tracebacks with execution history (config defaults to ``True``).
+
 In some cases it is convenient to have a custom TaskTiger launch script. For
 example, your application may have a ``manage.py`` command that sets up the
 environment and you may want to launch TaskTiger workers using that script. To

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -171,6 +171,11 @@ class TaskTiger(object):
             # forked child process. Useful to do things like close file handles
             # or reinitialize crypto libraries.
             'CHILD_CONTEXT_MANAGERS': [],
+
+            # Store traceback in execution history for failed tasks. This can
+            # increase Redis storage requirements and therefore can be disabled
+            # if that is a concern.
+            'STORE_TRACEBACKS': True,
         }
         if config:
             self.config.update(config)
@@ -433,6 +438,9 @@ class TaskTiger(object):
                                              'separated by comma.')
 @click.option('-M', '--max-workers-per-queue', help='Maximum workers allowed '
                                                     'to process a queue', type=int)
+@click.option('--store-tracebacks/--no-store-tracebacks',
+              help='Store tracebacks with execution history',
+              default=True)
 @click.option('-h', '--host', help='Redis server hostname')
 @click.option('-p', '--port', help='Redis server port')
 @click.option('-a', '--password', help='Redis password')

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -304,7 +304,7 @@ class TaskTiger(object):
         run_worker(args=args, obj=self)
 
     def run_worker(self, queues=None, module=None, exclude_queues=None,
-                   max_workers_per_queue=None):
+                   max_workers_per_queue=None, store_tracebacks=None):
         """
         Main worker entry point method.
 
@@ -323,7 +323,8 @@ class TaskTiger(object):
             worker = Worker(self,
                             queues.split(',') if queues else None,
                             exclude_queues.split(',') if exclude_queues else None,
-                            max_workers_per_queue=max_workers_per_queue)
+                            max_workers_per_queue=max_workers_per_queue,
+                            store_tracebacks=store_tracebacks)
             worker.run()
         except Exception:
             self.log.exception('Unhandled exception')

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -441,7 +441,7 @@ class TaskTiger(object):
                                                     'to process a queue', type=int)
 @click.option('--store-tracebacks/--no-store-tracebacks',
               help='Store tracebacks with execution history',
-              default=True)
+              default=None)
 @click.option('-h', '--host', help='Redis server hostname')
 @click.option('-p', '--port', help='Redis server port')
 @click.option('-a', '--password', help='Redis password')

--- a/tasktiger/logging.py
+++ b/tasktiger/logging.py
@@ -9,6 +9,6 @@ def tasktiger_processor(logger, method_name, event_dict):
     """
 
     if g['current_tasks'] is not None and not g['current_task_is_batch']:
-        event_dict['task_id'] = self.tiger.current_task.id
+        event_dict['task_id'] = g['current_tasks'][0].id
 
     return event_dict

--- a/tasktiger/logging.py
+++ b/tasktiger/logging.py
@@ -1,7 +1,7 @@
 from _internal import g
 
 
-def tasktiger_processor(self, logger, method_name, event_dict):
+def tasktiger_processor(logger, method_name, event_dict):
     """
     TaskTiger structlog processor.
 

--- a/tasktiger/logging.py
+++ b/tasktiger/logging.py
@@ -1,0 +1,14 @@
+from _internal import g
+
+
+def tasktiger_processor(self, logger, method_name, event_dict):
+    """
+    TaskTiger structlog processor.
+
+    Inject the current task id for non-batch tasks.
+    """
+
+    if g['current_tasks'] is not None and not g['current_task_is_batch']:
+        event_dict['task_id'] = self.tiger.current_task.id
+
+    return event_dict

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -94,9 +94,9 @@ class Worker(object):
                 self.max_workers_per_queue >= 1)
 
         if store_tracebacks is not None:
-            self.store_tracebacks = store_tracebacks
+            self.store_tracebacks = bool(store_tracebacks)
         else:
-            self.store_tracebacks = self.config['STORE_TRACEBACKS']
+            self.store_tracebacks = bool(self.config['STORE_TRACEBACKS'])
 
         self._stop_requested = False
 

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -49,7 +49,8 @@ class WorkerContextManagerStack(ExitStack):
 
 class Worker(object):
     def __init__(self, tiger, queues=None, exclude_queues=None,
-                 single_worker_queues=None, max_workers_per_queue=None, store_tracebacks=None):
+                 single_worker_queues=None, max_workers_per_queue=None,
+                 store_tracebacks=None):
         """
         Internal method to initialize a worker.
         """
@@ -93,10 +94,11 @@ class Worker(object):
         assert (self.max_workers_per_queue is None or
                 self.max_workers_per_queue >= 1)
 
-        if store_tracebacks is not None:
-            self.store_tracebacks = bool(store_tracebacks)
+        if store_tracebacks is None:
+            self.store_tracebacks = bool(self.config.get(
+                'STORE_TRACEBACKS', True))
         else:
-            self.store_tracebacks = bool(self.config['STORE_TRACEBACKS'])
+            self.store_tracebacks = bool(store_tracebacks)
 
         self._stop_requested = False
 


### PR DESCRIPTION
Adds:
* New option to disable saving tracebacks in execution histories
* Structlog processor that automatically injects task id