### PR TITLE
Fix worker test failures caused by sleep race conditions

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,4 +75,4 @@ def external_worker(n=None, patch_config=None, max_workers_per_queue=None):
     if max_workers_per_queue is not None:
         worker.max_workers_per_queue = max_workers_per_queue
 
-    worker.run(once=True)
+    worker.run(once=True, force_once=True)


### PR DESCRIPTION
This issue has been causing random test failures over the past few months ([example](https://circleci.com/gh/closeio/tasktiger/739))