### PR TITLE
Only queue periodic tasks for queues the worker is responsible for

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -21,7 +21,7 @@ class Task(object):
         """
 
         if func and queue is None:
-            queue = getattr(func, '_task_queue', tiger.config['DEFAULT_QUEUE'])
+            queue = Task.queue_from_function(func, tiger)
 
         self.tiger = tiger
         self._func = func
@@ -417,6 +417,11 @@ class Task(object):
                     tasks.append(task)
 
         return n, tasks
+
+    @classmethod
+    def queue_from_function(cls, func, tiger):
+        """Get queue from function."""
+        return getattr(func, '_task_queue', tiger.config['DEFAULT_QUEUE'])
 
     def n_executions(self):
         """

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -893,6 +893,11 @@ class Worker(object):
         # queued yet. Otherwise, assume another worker is doing this.
         funcs = self.tiger.periodic_task_funcs.values()
 
+        # Only queue periodic tasks for queues this worker is responsible
+        # for.
+        funcs = [f for f in funcs if self._filter_queues(
+            [Task.queue_from_function(f, self.tiger)])]
+
         if not funcs:
             return
 


### PR DESCRIPTION
The current behavior can be somewhat unexpected and it potentially causes some performance impact when you are starting/stopping large numbers of workers that don't process periodic tasks.