### PR TITLE
Remove lock when queueing periodic tasks

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -146,9 +146,6 @@ class TaskTiger(object):
             # How often to print stats.
             'STATS_INTERVAL': 60,
 
-            # Upper bound for the time it takes to queue all periodic tasks.
-            'QUEUE_PERIODIC_TASKS_LOCK_TIMEOUT': 10,
-
             # Single worker queues can reduce redis activity in some use cases
             # by locking at the queue level instead of just at the task or task
             # group level. These queues will only allow a single worker to

--- a/tests/tasks_periodic.py
+++ b/tests/tasks_periodic.py
@@ -15,3 +15,13 @@ def periodic_task():
     """Periodic task."""
     conn = redis.Redis(db=TEST_DB, decode_responses=True)
     conn.incr('period_count', 1)
+
+
+@tiger.task(schedule=periodic(seconds=1), queue='periodic_ignore')
+def periodic_task_ignore():
+    """
+    Ignored periodic task.
+
+    This task should never get queued.
+    """
+    pass

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -56,7 +56,12 @@ class TestPeriodicTasks(BaseTestCase):
         assert f[0](datetime.datetime(2010, 1, 1, 0, 1), *f[1]) == None
 
     def test_periodic_execution(self):
-        """Test periodic task execution."""
+        """
+        Test periodic task execution.
+
+        Test periodic_task() runs as expected and periodic_task_ignore()
+        is not queued.
+        """
 
         # After the first worker run, the periodic task will be queued.
         # Note that since periodic tasks register with the Tiger instance, it
@@ -73,9 +78,9 @@ class TestPeriodicTasks(BaseTestCase):
             self._ensure_queues(scheduled={'periodic': 1})
         except AssertionError:
             Worker(tiger).run(once=True)
+            self._ensure_queues(scheduled={'periodic': 1})
             assert int(self.conn.get('period_count')) == 1
             self.conn.delete('period_count')
-            self._ensure_queues(scheduled={'periodic': 1})
 
         def ensure_run(n):
             # Run worker twice (once to move from scheduled to queued, and once

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,6 +56,8 @@ def get_tiger():
         },
 
         'SINGLE_WORKER_QUEUES': ['swq'],
+
+        'EXCLUDE_QUEUES': ['periodic_ignore'],
     })
     tiger.log.setLevel(logging.CRITICAL)
     return tiger


### PR DESCRIPTION
@tsx pointed out that my last PR https://github.com/closeio/tasktiger/pull/132 has a regression since we use a single lock to queue periodic tasks we can no longer rely on `(assuming other process will)` since they may be queueing tasks for queues the current process doesn't process (or vice versa). Potential fixes:
* Remove lock - not sure if it is really needed
* Revert previous PR
* Implement a more complicated per task or per queue locking mechanism

@thomasst do you remember what the lock was doing for this?