### PR TITLE
Log Task Approximate Execution Time

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -764,10 +764,13 @@ class Worker(object):
         """
         log = self.log.bind(queue=queue, task_id=task.id)
 
+        when = time.time()
+        execution_duration = task.ts and when - task.ts
+
         def _mark_done():
             # Remove the task from active queue
             task._move(from_state=ACTIVE)
-            log.info('done')
+            log.info('done', execution_duration=execution_duration)
 
         if success:
             _mark_done()
@@ -809,10 +812,9 @@ class Worker(object):
 
             state = ERROR
 
-            when = time.time()
-
             log_context = {
-                'func': task.serialized_func
+                'func': task.serialized_func,
+                'execution_duration': execution_duration,
             }
 
             if should_retry:

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -627,7 +627,7 @@ class Worker(object):
             log.debug('processed', attempted=len(tasks),
                       processed=processed_count)
             for task in processed_tasks:
-                self._finish_task_processing(queue, task, success)
+                self._finish_task_processing(queue, task, success, now)
 
         return processed_count
 
@@ -756,7 +756,7 @@ class Worker(object):
 
         return success, ready_tasks
 
-    def _finish_task_processing(self, queue, task, success):
+    def _finish_task_processing(self, queue, task, success, start_time):
         """
         After a task is executed, this method is called and ensures that
         the task gets properly removed from the ACTIVE queue and, in case of an
@@ -765,7 +765,7 @@ class Worker(object):
         log = self.log.bind(queue=queue, task_id=task.id)
 
         when = time.time()
-        processing_duration = task.ts and when - task.ts
+        processing_duration = when - start_time
 
         def _mark_done():
             # Remove the task from active queue

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -764,8 +764,8 @@ class Worker(object):
         """
         log = self.log.bind(queue=queue, task_id=task.id)
 
-        when = time.time()
-        processing_duration = when - start_time
+        now = time.time()
+        processing_duration = now - start_time
 
         def _mark_done():
             # Remove the task from active queue
@@ -811,6 +811,8 @@ class Worker(object):
                     should_retry = True
 
             state = ERROR
+
+            when = now
 
             log_context = {
                 'func': task.serialized_func,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -765,12 +765,12 @@ class Worker(object):
         log = self.log.bind(queue=queue, task_id=task.id)
 
         when = time.time()
-        execution_duration = task.ts and when - task.ts
+        processing_duration = task.ts and when - task.ts
 
         def _mark_done():
             # Remove the task from active queue
             task._move(from_state=ACTIVE)
-            log.info('done', execution_duration=execution_duration)
+            log.info('done', processing_duration=processing_duration)
 
         if success:
             _mark_done()
@@ -814,7 +814,7 @@ class Worker(object):
 
             log_context = {
                 'func': task.serialized_func,
-                'execution_duration': execution_duration,
+                'processing_duration': processing_duration,
             }
 
             if should_retry:


### PR DESCRIPTION
Per https://github.com/closeio/tasktiger/issues/20, the `task.ts` here should be _close enough_ that the information will still be useful.

In cases where the batch size is greater than one, this won't be super accurate. `task.ts` is set based on when the batch starts, so if the batch size is `50`, then later tasks will report cumulative execution time for the batch rather than just the individual task.

