### PR TITLE
Fix Default Periodic Task Unique ID

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -75,6 +75,9 @@ class Task(object):
         if max_queue_size is None:
             max_queue_size = getattr(func, '_task_max_queue_size', None)
 
+        # normalize falsy args/kwargs to empty structures
+        args = args or []
+        kwargs = kwargs or {}
         if unique:
             task_id = gen_unique_id(serialized_name, args, kwargs)
         else:

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -4,8 +4,9 @@ import datetime
 import time
 
 from tasktiger import Worker, periodic
+from tasktiger import Task, gen_unique_id, serialize_func_name, QUEUED
 
-from .tasks_periodic import tiger
+from .tasks_periodic import tiger, periodic_task
 from .test_base import BaseTestCase
 
 
@@ -107,3 +108,79 @@ class TestPeriodicTasks(BaseTestCase):
         time.sleep(1)
 
         ensure_run(2)
+
+    def test_periodic_execution_unique_ids(self):
+        """
+        Test that periodic tasks generate the same unique ids
+
+        When a periodic task is scheduled initially as part of worker startup
+        vs re-scheduled from within python the unique id generated should be
+        the same. If they aren't it could result in duplicate tasks.
+        """
+        # Sleep until the next second
+        now = datetime.datetime.utcnow()
+        time.sleep(1 - now.microsecond / 10.0 ** 6)
+
+        # After the first worker run, the periodic task will be queued.
+        # Note that since periodic tasks register with the Tiger instance, it
+        # must be the same instance that was used to decorate the task. We
+        # therefore use `tiger` from the tasks module instead of `self.tiger`.
+        self._ensure_queues()
+        Worker(tiger).run(once=True)
+        self._ensure_queues(scheduled={'periodic': 1})
+        time.sleep(1)
+        Worker(tiger).run(once=True)
+        self._ensure_queues(queued={'periodic': 1})
+
+        # generate the expected unique id
+        expected_unique_id = gen_unique_id(
+            serialize_func_name(periodic_task), [], {}
+        )
+
+        # pull task out of the queue by id. If found, then the id is correct
+        task = Task.from_id(tiger, 'periodic', QUEUED, expected_unique_id)
+        assert task is not None
+
+        # execute and reschedule the task
+        self._ensure_queues(queued={'periodic': 1})
+        Worker(tiger).run(once=True)
+        self._ensure_queues(scheduled={'periodic': 1})
+
+        # wait for the task to need to be queued
+        time.sleep(1)
+        Worker(tiger).run(once=True)
+        self._ensure_queues(queued={'periodic': 1})
+
+        # The unique id shouldn't change between executions. Try finding the
+        # task by id again
+        task = Task.from_id(tiger, 'periodic', QUEUED, expected_unique_id)
+        assert task is not None
+
+    def test_periodic_execution_unique_ids_manual_scheduling(self):
+        """
+        Periodic tasks should have the same unique ids when manually scheduled
+
+        When a periodic task is scheduled initially as part of worker startup
+        vs ``.delay``'d manually, the unique id generated should be the same.
+        If they aren't it could result in duplicate tasks.
+        """
+        # Sleep until the next second
+        now = datetime.datetime.utcnow()
+        time.sleep(1 - now.microsecond / 10.0 ** 6)
+
+        # After the first worker run, the periodic task will be queued.
+        # Note that since periodic tasks register with the Tiger instance, it
+        # must be the same instance that was used to decorate the task. We
+        # therefore use `tiger` from the tasks module instead of `self.tiger`.
+        self._ensure_queues()
+        Worker(tiger).run(once=True)
+        self._ensure_queues(scheduled={'periodic': 1})
+        time.sleep(1)
+        Worker(tiger).run(once=True)
+        self._ensure_queues(queued={'periodic': 1})
+
+        # schedule the task manually
+        periodic_task.delay()
+
+        # make sure a duplicate wasn't scheduled
+        self._ensure_queues(queued={'periodic': 1})


### PR DESCRIPTION
Related Issue: https://github.com/closeio/tasktiger/issues/146

Per the issue, manually scheduled and automatically queued period tasks _should_ have the same unique id, but currently don't.
```python
periodic_task.delay()  # id == hash(function_name, [], {})
Worker().run()  # periodic_task.id == hash(function_name, None, None)
```

If this happens then there can end up being multiple versions of an argument-less periodic task floating around in the queue.

This change fixes that behavior by always defaulting args/kwargs to `[]`/`{}` before generating the unique id. Also, this change introduces behavior to self-correct ids when rescheduling the task for the future. I've added a test confirming this behavior, but it is a departure from what the current behavior is. I'm not sure if we want to keep that aspect of this change or just say that tasks should be manually identified/purged when there's an issue like the one linked.