### PR TITLE
Improve worker shutdown

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -1,4 +1,3 @@
-import binascii
 from collections import OrderedDict
 import errno
 import fcntl

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -598,9 +598,13 @@ class Worker(object):
                     if results[0]:
                         # Purge pipe so select will pause on next call
                         try:
+                            # Linux:
+                            #   Raises IOError if it would block
+                            #
+                            # macOS:
+                            #   Returns empty string if it would block
                             opened_fd.read(1)
                         except IOError:
-                            # Raised if read would block
                             pass
 
                 except select.error as e:

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -588,15 +588,20 @@ class Worker(object):
                     # macOS:
                     #   - 15 (SIGTERM) when parent receives SIGTERM
                     #   - 20 (SIGCHLD) when child exits
-                    select.select(
+                    results = select.select(
                         [pipe_r],
                         [],
                         [],
                         self.config['ACTIVE_TASK_UPDATE_TIMER'],
                     )
 
-                    # Purge pipe so select will pause on next call
-                    opened_fd.read(1)
+                    if results[0]:
+                        # Purge pipe so select will pause on next call
+                        try:
+                            opened_fd.read(1)
+                        except IOError:
+                            # Raised if read would block
+                            pass
 
                 except select.error as e:
                     if e.args[0] != errno.EINTR:

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -598,11 +598,13 @@ class Worker(object):
                     if results[0]:
                         # Purge pipe so select will pause on next call
                         try:
+                            # Behavior of a would be blocking read()
                             # Linux:
-                            #   Raises IOError if it would block
+                            #   Python 2.7 Raises IOError
+                            #   Python 3.x returns empty string
                             #
                             # macOS:
-                            #   Returns empty string if it would block
+                            #   Returns empty string
                             opened_fd.read(1)
                         except IOError:
                             pass


### PR DESCRIPTION
Once the parent process receives a SIGTERM the `select.select()` will always immediately return. This causes `self._heartbeat()` to be called repeatedly as fast as possible causing a large load on Redis until the child process exits.