### PR TITLE
Lock for scheduled tasks queueing

### DIFF
--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -158,10 +158,10 @@ class TaskTiger(object):
             # time to requeue a batch of tasks.
             'REQUEUE_EXPIRED_TASKS_INTERVAL': 30,
             'REQUEUE_EXPIRED_TASKS_BATCH_SIZE': 10,
-            # Maximum time the scheduled tasks queue lock is held. Other
+            # Time the scheduled tasks queue lock is held (in seconds). Other
             # workers processing the same queues won't be scheduling tasks as
             # long as the lock is held to prevent unnecessary load on Redis.
-            'QUEUE_SCHEDULED_TASKS_TIME': 10,
+            'QUEUE_SCHEDULED_TASKS_TIME': 1,
             # Set up queues that will be processed in batch, i.e. multiple jobs
             # are taken out of the queue at the same time and passed as a list
             # to the worker method. Takes a dict where the key represents the

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -158,6 +158,10 @@ class TaskTiger(object):
             # time to requeue a batch of tasks.
             'REQUEUE_EXPIRED_TASKS_INTERVAL': 30,
             'REQUEUE_EXPIRED_TASKS_BATCH_SIZE': 10,
+            # Maximum time the scheduled tasks queue lock is held. Other
+            # workers processing the same queues won't be scheduling tasks as
+            # long as the lock is held to prevent unnecessary load on Redis.
+            'QUEUE_SCHEDULED_TASKS_TIME': 10,
             # Set up queues that will be processed in batch, i.e. multiple jobs
             # are taken out of the queue at the same time and passed as a list
             # to the worker method. Takes a dict where the key represents the

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -175,7 +175,7 @@ class Worker(object):
             timeout=self.config['QUEUE_SCHEDULED_TASKS_TIME'],
         )
 
-        # Another worker is already doing this.
+        # See if any worker has recently queued scheduled tasks.
         acquired = lock.acquire(blocking=False)
         if not acquired:
             return
@@ -211,8 +211,6 @@ class Worker(object):
             if result:
                 self.connection.publish(self._key('activity'), queue)
                 self._did_work = True
-
-        lock.release()
 
     def _wait_for_new_tasks(self, timeout=0, batch_timeout=0):
         """

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -117,10 +117,11 @@ class Worker(object):
         # A worker group is a group of workers that process the same set of
         # queues. This allows us to use worker group-specific locks to reduce
         # Redis load.
-        self.worker_group_name = hashlib.sha256(json.dumps([
-            sorted(self.only_queues),
-            sorted(self.exclude_queues),
-        ]).encode('utf8')).hexdigest()
+        self.worker_group_name = hashlib.sha256(
+            json.dumps(
+                [sorted(self.only_queues), sorted(self.exclude_queues),]
+            ).encode('utf8')
+        ).hexdigest()
 
     def _install_signal_handlers(self):
         """
@@ -165,9 +166,7 @@ class Worker(object):
         periodically.
         """
         lock_name = self._key(
-            'lock',
-            'queue_scheduled_tasks',
-            self.worker_group_name
+            'lock', 'queue_scheduled_tasks', self.worker_group_name
         )
         lock = Lock(
             self.connection,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -165,19 +165,17 @@ class Worker(object):
         them in the QUEUED queue for execution. This should be called
         periodically.
         """
-        lock_name = self._key(
-            'lock', 'queue_scheduled_tasks', self.worker_group_name
-        )
-        lock = Lock(
-            self.connection,
-            lock_name,
-            timeout=self.config['QUEUE_SCHEDULED_TASKS_TIME'],
-        )
+        timeout = self.config['QUEUE_SCHEDULED_TASKS_TIME']
+        if timeout > 0:
+            lock_name = self._key(
+                'lock', 'queue_scheduled_tasks', self.worker_group_name
+            )
+            lock = Lock(self.connection, lock_name, timeout=timeout)
 
-        # See if any worker has recently queued scheduled tasks.
-        acquired = lock.acquire(blocking=False)
-        if not acquired:
-            return
+            # See if any worker has recently queued scheduled tasks.
+            acquired = lock.acquire(blocking=False)
+            if not acquired:
+                return
 
         queues = set(
             self._filter_queues(self.connection.smembers(self._key(SCHEDULED)))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,14 +10,15 @@ from .config import DELAY, TEST_DB, REDIS_HOST
 TEST_TIGER_CONFIG = {
     # We need this 0 here so we don't pick up scheduled tasks when
     # doing a single worker run.
-    'SELECT_TIMEOUT': 0,
     'ACTIVE_TASK_UPDATE_TIMEOUT': 2 * DELAY,
-    'REQUEUE_EXPIRED_TASKS_INTERVAL': DELAY,
-    'LOCK_RETRY': DELAY * 2.0,
-    'DEFAULT_RETRY_METHOD': fixed(DELAY, 2),
     'BATCH_QUEUES': {'batch': 3},
-    'SINGLE_WORKER_QUEUES': ['swq'],
+    'DEFAULT_RETRY_METHOD': fixed(DELAY, 2),
     'EXCLUDE_QUEUES': ['periodic_ignore'],
+    'LOCK_RETRY': DELAY * 2.0,
+    'QUEUE_SCHEDULED_TASKS_TIME': DELAY,
+    'REQUEUE_EXPIRED_TASKS_INTERVAL': DELAY,
+    'SELECT_TIMEOUT': 0,
+    'SINGLE_WORKER_QUEUES': ['swq'],
 }
 
 


### PR DESCRIPTION
First attempt to address https://github.com/closeio/tasktiger/issues/89#issuecomment-609963574

Alternatively, we could lock for a shorter amount of time (e.g. a second) and not release the lock, which saves on Redis instructions for releasing the lock, and also prevents us from attempting to schedule tasks too often.