### PR TITLE
Store tiger instance in global task context

### DIFF
--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -174,5 +174,6 @@ class classproperty(property):
 
     Works like @property but on classes.
     """
+
     def __get__(desc, self, cls):
         return desc.fget(cls)

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -166,3 +166,13 @@ def queue_matches(queue, only_queues=None, exclude_queues=None):
         if part in only_queues:
             return True
     return not only_queues
+
+
+class classproperty(property):
+    """
+    Simple class property implementation.
+
+    Works like @property but on classes.
+    """
+    def __get__(desc, self, cls):
+        return desc.fget(cls)

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -36,7 +36,7 @@ g_fork_lock = threading.Lock()
 # Global task context. We store this globally (and not on the TaskTiger
 # instance) for consistent results just in case the user has multiple TaskTiger
 # instances.
-g = {'current_task_is_batch': None, 'current_tasks': None}
+g = {'tiger': None, 'current_task_is_batch': None, 'current_tasks': None}
 
 # from rq
 def import_attribute(name):

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -295,6 +295,7 @@ class Task(object):
 
         g['current_task_is_batch'] = is_batch_func
         g['current_tasks'] = [self]
+        g['tiger'] = self.tiger
 
         try:
             if is_batch_func:
@@ -304,6 +305,7 @@ class Task(object):
         finally:
             g['current_task_is_batch'] = None
             g['current_tasks'] = None
+            g['tiger'] = None
 
     def delay(self, when=None, max_queue_size=None):
         tiger = self.tiger

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -14,6 +14,7 @@ from .redis_semaphore import Semaphore
 from .redis_scripts import RedisScripts
 
 from ._internal import (
+    classproperty,
     g,
     serialize_func_name,
     QUEUED,
@@ -225,14 +226,14 @@ class TaskTiger(object):
 
     def _get_current_task(self):
         if g['current_tasks'] is None:
-            raise RuntimeError('Must be accessed from within a task')
+            raise RuntimeError('Must be accessed from within a task.')
         if g['current_task_is_batch']:
             raise RuntimeError('Must use current_tasks in a batch task.')
         return g['current_tasks'][0]
 
     def _get_current_tasks(self):
         if g['current_tasks'] is None:
-            raise RuntimeError('Must be accessed from within a task')
+            raise RuntimeError('Must be accessed from within a task.')
         if not g['current_task_is_batch']:
             raise RuntimeError('Must use current_task in a non-batch task.')
         return g['current_tasks']
@@ -243,6 +244,15 @@ class TaskTiger(object):
     """
     current_task = property(_get_current_task)
     current_tasks = property(_get_current_tasks)
+
+    @classproperty
+    def current_instance(self):
+        """
+        Access the current TaskTiger instance from within a task.
+        """
+        if g['tiger'] is None:
+            raise RuntimeError('Must be accessed from within a task.')
+        return g['tiger']
 
     def _key(self, *parts):
         """

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -363,6 +363,7 @@ class Worker(object):
             func = tasks[0].func
 
             is_batch_func = getattr(func, '_task_batch', False)
+            g['tiger'] = self.tiger
             g['current_task_is_batch'] = is_batch_func
 
             with WorkerContextManagerStack(

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -4,7 +4,7 @@ import time
 
 import redis
 
-from tasktiger import RetryException
+from tasktiger import RetryException, TaskTiger
 from tasktiger.retry import fixed
 
 from .config import DELAY, TEST_DB, REDIS_HOST
@@ -150,6 +150,19 @@ def verify_current_tasks(tasks):
 
             tasks = tiger.current_tasks
             conn.rpush('task_ids', *[t.id for t in tasks])
+
+
+@tiger.task()
+def verify_tasktiger_instance():
+    # Not necessarily the same object, but the same configuration.
+    config_1 = dict(TaskTiger.current_instance.config)
+    config_2 = dict(tiger.config)
+
+    # Changed during the test case, so this may differ.
+    config_1.pop("ALWAYS_EAGER")
+    config_2.pop("ALWAYS_EAGER")
+
+    assert config_1 == config_2
 
 
 @tiger.task()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -43,6 +43,7 @@ from .tasks import (
     unique_exception_task,
     verify_current_task,
     verify_current_tasks,
+    verify_tasktiger_instance,
 )
 from .utils import Patch, external_worker, get_tiger
 
@@ -1048,6 +1049,9 @@ class TestTasks(BaseTestCase):
 
 
 class TestCurrentTask(BaseTestCase):
+    """
+    Ensure current_task/current_tasks are set.
+    """
     def test_current_task(self):
         task = Task(self.tiger, verify_current_task)
         task.delay()
@@ -1078,6 +1082,22 @@ class TestCurrentTask(BaseTestCase):
         task.delay()
         assert not self.conn.exists('runtime_error')
         assert self.conn.lrange('task_ids', 0, -1) == [task.id]
+
+
+class TestTaskTigerGlobal(BaseTestCase):
+    """
+    Ensure TaskTiger.current_instance is set.
+    """
+    def test_task(self):
+        task = Task(self.tiger, verify_tasktiger_instance)
+        task.delay()
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues()
+
+    def test_eager(self):
+        self.tiger.config['ALWAYS_EAGER'] = True
+        task = Task(self.tiger, verify_tasktiger_instance)
+        task.delay()
 
 
 class TestReliability(BaseTestCase):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1052,6 +1052,7 @@ class TestCurrentTask(BaseTestCase):
     """
     Ensure current_task/current_tasks are set.
     """
+
     def test_current_task(self):
         task = Task(self.tiger, verify_current_task)
         task.delay()
@@ -1088,6 +1089,7 @@ class TestTaskTigerGlobal(BaseTestCase):
     """
     Ensure TaskTiger.current_instance is set.
     """
+
     def test_task(self):
         task = Task(self.tiger, verify_tasktiger_instance)
         task.delay()


### PR DESCRIPTION
This makes it easier for libraries (e.g. FlowFish) to access the TaskTiger instance to queue further tasks.

```
from tasktiger._internal import g

def my_task(...):
    tiger = g["tiger"]
    tiger.delay(more_tasks)
```

I don't like that it's importing `_internal` but wasn't sure if there's a good way to expose it, perhaps just `from tasktiger import g`?