### PR TITLE
Poll for new tasks

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -285,7 +285,7 @@ class Task(object):
             _key(from_state), queue, _key(from_state, queue), client=pipeline
         )
 
-        if to_state == QUEUED:
+        if to_state == QUEUED and self.tiger.config["PUBLISH_QUEUED_TASKS"]:
             pipeline.publish(_key('activity'), queue)
 
         try:
@@ -361,7 +361,7 @@ class Task(object):
             mode='nx',
             client=pipeline,
         )
-        if state == QUEUED:
+        if state == QUEUED and tiger.config["PUBLISH_QUEUED_TASKS"]:
             pipeline.publish(tiger._key('activity'), self.queue)
         pipeline.execute()
 

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -198,7 +198,7 @@ class TaskTiger(object):
             # Set to > 0 to poll periodically for queues with tasks. Otherwise
             # subscribe to the activity channel. Use for more efficient task
             # processing with a large amount of workers.
-            'POLL_QUEUED_TASKS': 0,
+            'POLL_TASK_QUEUES_INTERVAL': 0,
         }
         if config:
             self.config.update(config)

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -195,7 +195,7 @@ class TaskTiger(object):
             # increase Redis storage requirements and therefore can be disabled
             # if that is a concern.
             'STORE_TRACEBACKS': True,
-            # Set to > 0 to poll periodically for queued tasks. Otherwise
+            # Set to > 0 to poll periodically for queues with tasks. Otherwise
             # subscribe to the activity channel. Use for more efficient task
             # processing with a large amount of workers.
             'POLL_QUEUED_TASKS': 0,

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -199,6 +199,9 @@ class TaskTiger(object):
             # subscribe to the activity channel. Use for more efficient task
             # processing with a large amount of workers.
             'POLL_TASK_QUEUES_INTERVAL': 0,
+            # Whether to publish new tasks to the activity channel. Only set to
+            # False if all the workers are polling queues.
+            'PUBLISH_QUEUED_TASKS': True,
         }
         if config:
             self.config.update(config)

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -195,6 +195,10 @@ class TaskTiger(object):
             # increase Redis storage requirements and therefore can be disabled
             # if that is a concern.
             'STORE_TRACEBACKS': True,
+            # Set to > 0 to poll periodically for queued tasks. Otherwise
+            # subscribe to the activity channel. Use for more efficient task
+            # processing with a large amount of workers.
+            'POLL_QUEUED_TASKS': 0,
         }
         if config:
             self.config.update(config)

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -219,7 +219,7 @@ class Worker(object):
         This is only used when using polling to get queues with queued tasks.
         """
         if not self._did_work:
-            time.sleep(self.config["POLL_QUEUED_TASKS"])
+            time.sleep(self.config["POLL_TASK_QUEUES_INTERVAL"])
         self._refresh_queue_set()
 
     def _pubsub_for_queues(self, timeout=0, batch_timeout=0):
@@ -1143,7 +1143,7 @@ class Worker(object):
         # Then, listen to the activity channel.
         # XXX: This can get inefficient when having lots of queues.
 
-        if self.config["POLL_QUEUED_TASKS"]:
+        if self.config["POLL_TASK_QUEUES_INTERVAL"]:
             self._pubsub = None
         else:
             self._pubsub = self.connection.pubsub()

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -207,7 +207,8 @@ class Worker(object):
             # XXX: ideally this would be in the same pipeline, but we only want
             # to announce if there was a result.
             if result:
-                self.connection.publish(self._key('activity'), queue)
+                if self.config["PUBLISH_QUEUED_TASKS"]:
+                    self.connection.publish(self._key('activity'), queue)
                 self._did_work = True
 
     def _poll_for_queues(self):


### PR DESCRIPTION
Ability to configure a polling interval for new task to reduce load when there are many workers & tasks. Instead of subscribing to the activity channel, which results in N_WORKERS messages for each task (and then each of them polling for the task), we just poll periodically. Downside is that with polling enabled and few workers it might take up to the polling interval to pick up a new task.