### PR TITLE
Add latest python and redis test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
       - test-3.6
       - test-3.7
       - test-3.8
+      - test-latest
       - black
 
 defaults: &defaults
@@ -39,6 +40,11 @@ jobs:
     docker:
     - image: circleci/python:3.8
     - image: redis:4.0.6
+  test-latest:
+    <<: *defaults
+    docker:
+      - image: circleci/python:latest
+      - image: redis:latest
   black:
     working_directory: ~/code
     docker:


### PR DESCRIPTION
This tested Python 3.9.2 and Redis 6.2.0 automatically.

Should we keep this test to check if changes are forward compatible?

/cc @AlecRosenbaum 