### PR TITLE
Include queue name in task ID generation

### DIFF
--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -57,14 +57,19 @@ def gen_id():
     return binascii.b2a_hex(os.urandom(32)).decode('utf8')
 
 
-def gen_unique_id(serialized_name, args, kwargs):
+def gen_unique_id(queue, serialized_name, args, kwargs):
     """
     Generates and returns a hex-encoded 256-bit ID for the given task name and
     args. Used to generate IDs for unique tasks or for task locks.
     """
     return hashlib.sha256(
         json.dumps(
-            {'func': serialized_name, 'args': args, 'kwargs': kwargs},
+            {
+                'queue': queue,
+                'func': serialized_name,
+                'args': args,
+                'kwargs': kwargs,
+            },
             sort_keys=True,
         ).encode('utf8')
     ).hexdigest()

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -91,12 +91,13 @@ class Task(object):
         if unique or unique_key:
             if unique_key:
                 task_id = gen_unique_id(
+                    queue,
                     serialized_name,
                     None,
                     {key: kwargs.get(key) for key in unique_key},
                 )
             else:
-                task_id = gen_unique_id(serialized_name, args, kwargs)
+                task_id = gen_unique_id(queue, serialized_name, args, kwargs)
         else:
             task_id = gen_id()
 
@@ -581,7 +582,7 @@ class Task(object):
             # between executions
             task = self.clone()
             task._data['id'] = gen_unique_id(
-                task.serialized_func, task.args, task.kwargs
+                task.queue, task.serialized_func, task.args, task.kwargs
             )
             task.delay(when=when)
         return when


### PR DESCRIPTION
This avoids a "task not found" scenario where we queue a unique task into several queues.

For example, if we queue a unique task with ID X into queues A and B, and the task X finishes on queue A first before being processed by queue B, then the task ID X would still be queued in queue B, but the worker would not be able to find the task since the task key is deleted.

We check (https://github.com/closeio/tasktiger/blob/f48fe03b7c845d032e9f2bdc01d1939f2a6db8ff/tasktiger/task.py#L262-L278) whether the task is in a different state (so you can e.g. requeue/schedule a unique task into the same queue without losing it), but it would not be reasonable to check all other queues.

I believe this shouldn't be a completely incompatible change to roll out since uniqueness isn't the same as locking as you can still queue a unique task even if one is being executed. Its main purpose is to reduce load. TaskTiger doesn't make any guarantees that unique tasks are not executed concurrently, however, in its current implementation it doesn't do that and instead schedules the unique task for later execution if one is already running (https://github.com/closeio/tasktiger/blob/f48fe03b7c845d032e9f2bdc01d1939f2a6db8ff/tasktiger/worker.py#L797-L804).
