### PR TITLE
Drop some unnecessary requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 click==7.1.2
-contextlib2==0.5.5; python_version < '3.3'
 redis==3.5.3
-six==1.15.0
 structlog==20.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
-install_requires = ['click', 'redis>=2', 'six', 'structlog']
+install_requires = ['click', 'redis>=2,<4', 'structlog']
 
 tests_require = install_requires + ['freezefrog', 'pytest', 'psutil']
 

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -9,7 +9,6 @@ import os
 import threading
 
 import redis
-import six
 
 from .exceptions import TaskImportError
 
@@ -151,12 +150,12 @@ def queue_matches(queue, only_queues=None, exclude_queues=None):
         '{kwarg} should be an iterable of strings, not a string directly. '
         'Did you mean `{kwarg}=[\'{val}\']`?'
     )
-    assert not isinstance(
-        only_queues, six.string_types
-    ), error_template.format(kwarg='queues', val=only_queues)
-    assert not isinstance(
-        exclude_queues, six.string_types
-    ), error_template.format(kwarg='exclude_queues', val=exclude_queues)
+    assert not isinstance(only_queues, str), error_template.format(
+        kwarg='queues', val=only_queues
+    )
+    assert not isinstance(exclude_queues, str), error_template.format(
+        kwarg='exclude_queues', val=exclude_queues
+    )
 
     only_queues = only_queues or []
     exclude_queues = exclude_queues or []

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from contextlib import ExitStack
 import errno
 import fcntl
 import hashlib
@@ -24,11 +25,6 @@ from .runner import get_runner_class
 from .stats import StatsThread
 from .task import Task
 from .timeouts import JobTimeoutException
-
-if sys.version_info < (3, 3):
-    from contextlib2 import ExitStack
-else:
-    from contextlib import ExitStack
 
 LOCK_REDIS_KEY = 'qslock'
 


### PR DESCRIPTION
We don't support Python 2.7 anymore, so we don't need `contextlib2` or `six` anymore. Also, added a limitation on what versions it can install of `redis-py`: `redis-py>=2,<4`, since version 4 can be, in theory, breaking.