### PR TITLE
Drop redis-py 2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 click==7.1.2
-contextlib2==0.5.5; python_version < '3.3'
 redis==3.5.3
-six==1.15.0
 structlog==20.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
-install_requires = ['click', 'redis>=2,<4', 'structlog']
+install_requires = ['click', 'redis>=3,<4', 'structlog']
 
 tests_require = install_requires + ['freezefrog', 'pytest', 'psutil']
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
-install_requires = ['click', 'redis>=2', 'six', 'structlog']
+install_requires = ['click', 'redis>=2,<4', 'structlog']
 
 tests_require = install_requires + ['freezefrog', 'pytest', 'psutil']
 

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -8,11 +8,7 @@ import operator
 import os
 import threading
 
-import redis
-
 from .exceptions import TaskImportError
-
-REDIS_PY_3 = redis.VERSION[0] >= 3
 
 # Task states (represented by different queues)
 # Note some client code may rely on the string values (e.g. get_queue_stats).

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -9,7 +9,6 @@ import os
 import threading
 
 import redis
-import six
 
 from .exceptions import TaskImportError
 
@@ -151,12 +150,12 @@ def queue_matches(queue, only_queues=None, exclude_queues=None):
         '{kwarg} should be an iterable of strings, not a string directly. '
         'Did you mean `{kwarg}=[\'{val}\']`?'
     )
-    assert not isinstance(
-        only_queues, six.string_types
-    ), error_template.format(kwarg='queues', val=only_queues)
-    assert not isinstance(
-        exclude_queues, six.string_types
-    ), error_template.format(kwarg='exclude_queues', val=exclude_queues)
+    assert not isinstance(only_queues, str), error_template.format(
+        kwarg='queues', val=only_queues
+    )
+    assert not isinstance(exclude_queues, str), error_template.format(
+        kwarg='exclude_queues', val=exclude_queues
+    )
 
     only_queues = only_queues or []
     exclude_queues = exclude_queues or []

--- a/tasktiger/redis_semaphore.py
+++ b/tasktiger/redis_semaphore.py
@@ -3,8 +3,6 @@
 import os
 import time
 
-from ._internal import REDIS_PY_3
-
 SYSTEM_LOCK_ID = 'SYSTEM_LOCK'
 
 
@@ -71,10 +69,7 @@ class Semaphore(object):
         """
 
         pipeline = redis.pipeline()
-        if REDIS_PY_3:
-            pipeline.zadd(name, {SYSTEM_LOCK_ID: time.time() + timeout})
-        else:
-            pipeline.zadd(name, SYSTEM_LOCK_ID, time.time() + timeout)
+        pipeline.zadd(name, {SYSTEM_LOCK_ID: time.time() + timeout})
         pipeline.expire(
             name, timeout + 10
         )  # timeout plus buffer for troubleshooting

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -251,10 +251,7 @@ class Task(object):
                     _key(to_state, queue), when, self.id, mode, client=pipeline
                 )
             else:
-                if REDIS_PY_3:
-                    pipeline.zadd(_key(to_state, queue), {self.id: when})
-                else:
-                    pipeline.zadd(_key(to_state, queue), self.id, when)
+                pipeline.zadd(_key(to_state, queue), {self.id: when})
             pipeline.sadd(_key(to_state), queue)
         pipeline.zrem(_key(from_state, queue), self.id)
 

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -500,10 +500,7 @@ class Worker(object):
         """
         now = time.time()
         mapping = {task_id: now for task_id in task_ids}
-        if REDIS_PY_3:
-            self.connection.zadd(self._key(ACTIVE, queue), mapping)
-        else:
-            self.connection.zadd(self._key(ACTIVE, queue), **mapping)
+        self.connection.zadd(self._key(ACTIVE, queue), mapping)
 
     def _execute(self, queue, tasks, log, locks, queue_lock, all_task_ids):
         """

--- a/tests/test_redis_scripts.py
+++ b/tests/test_redis_scripts.py
@@ -1,7 +1,7 @@
 import pytest
 import redis
 
-from .utils import get_tiger, REDIS_PY_3
+from .utils import get_tiger
 
 
 class TestRedisScripts:
@@ -11,12 +11,6 @@ class TestRedisScripts:
         self.conn.flushdb()
         self.scripts = self.tiger.scripts
 
-    def _zadd(self, key, mapping):
-        if REDIS_PY_3:
-            return self.conn.zadd(key, mapping)
-        else:
-            return self.conn.zadd(key, **mapping)
-
     def teardown_method(self, method):
         self.conn.flushdb()
         self.conn.close()
@@ -24,7 +18,7 @@ class TestRedisScripts:
         self.conn.connection_pool.disconnect()
 
     def _test_zadd(self, mode):
-        self._zadd('z', {'key1': 2})
+        self.conn.zadd('z', {'key1': 2})
         self.scripts.zadd('z', 4, 'key1', mode=mode)
         self.scripts.zadd('z', 3, 'key1', mode=mode)
         self.scripts.zadd('z', 1, 'key2', mode=mode)
@@ -49,7 +43,7 @@ class TestRedisScripts:
         assert entries == [('key2', 2.0), ('key1', 4.0)]
 
     def test_zpoppush_1(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush('src', 'dst', 3, None, 10)
         assert result == ['a', 'b', 'c']
 
@@ -60,7 +54,7 @@ class TestRedisScripts:
         assert dst == [('a', 10.0), ('b', 10.0), ('c', 10.0)]
 
     def test_zpoppush_2(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush('src', 'dst', 100, None, 10)
         assert result == ['a', 'b', 'c', 'd']
 
@@ -71,7 +65,7 @@ class TestRedisScripts:
         assert dst == [('a', 10.0), ('b', 10.0), ('c', 10.0), ('d', 10.0)]
 
     def test_zpoppush_3(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush('src', 'dst', 3, 2, 10)
         assert result == ['a', 'b']
 
@@ -82,7 +76,7 @@ class TestRedisScripts:
         assert dst == [('a', 10.0), ('b', 10.0)]
 
     def test_zpoppush_withscores_1(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush(
             'src', 'dst', 3, None, 10, withscores=True
         )
@@ -95,7 +89,7 @@ class TestRedisScripts:
         assert dst == [('a', 10.0), ('b', 10.0), ('c', 10.0)]
 
     def test_zpoppush_withscores_2(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush(
             'src', 'dst', 100, None, 10, withscores=True
         )
@@ -108,7 +102,7 @@ class TestRedisScripts:
         assert dst == [('a', 10.0), ('b', 10.0), ('c', 10.0), ('d', 10.0)]
 
     def test_zpoppush_withscores_3(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         result = self.scripts.zpoppush('src', 'dst', 3, 2, 10, withscores=True)
         assert result == ['a', '1', 'b', '2']
 
@@ -122,10 +116,10 @@ class TestRedisScripts:
         """
         2 out of 4 items moved, so add_set contains "val"
         """
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         # Whether the members are in the destination ZSET doesn't make any
         # difference here.
-        self._zadd('dst', {'a': 5, 'b': 5})
+        self.conn.zadd('dst', {'a': 5, 'b': 5})
         self.conn.sadd('remove_set', 'val')
         result = self.scripts.zpoppush(
             'src',
@@ -151,7 +145,7 @@ class TestRedisScripts:
         """
         0 out of 4 items moved, so no sets were changed
         """
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         self.conn.sadd('remove_set', 'val')
         result = self.scripts.zpoppush(
             'src',
@@ -177,7 +171,7 @@ class TestRedisScripts:
         """
         4 out of 4 items moved, so both sets were changed
         """
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         self.conn.sadd('remove_set', 'val')
         result = self.scripts.zpoppush(
             'src',
@@ -200,9 +194,9 @@ class TestRedisScripts:
         assert self.conn.smembers('add_set') == {'val'}
 
     def test_zpoppush_ignore_if_exists_1(self):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         # Members that are in the destination ZSET are not updated here.
-        self._zadd('dst', {'a': 5, 'b': 5})
+        self.conn.zadd('dst', {'a': 5, 'b': 5})
         self.conn.sadd('remove_set', 'val')
         result = self.scripts.zpoppush(
             'src',
@@ -231,10 +225,10 @@ class TestRedisScripts:
         self.test_zpoppush_on_success_3(if_exists=('noupdate',))
 
     def _test_zpoppush_min_if_exists(self, expected_if_exists_score):
-        self._zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.conn.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         # Members that are in the destination ZSET are added to the if_exists
         # ZSET.
-        self._zadd('dst', {'a': 5})
+        self.conn.zadd('dst', {'a': 5})
         self.conn.sadd('remove_set', 'val')
         result = self.scripts.zpoppush(
             'src',
@@ -270,11 +264,11 @@ class TestRedisScripts:
         self._test_zpoppush_min_if_exists(20)
 
     def test_zpoppush_min_if_exists_2(self):
-        self._zadd('if_exists', {'a': 10})
+        self.conn.zadd('if_exists', {'a': 10})
         self._test_zpoppush_min_if_exists(10)
 
     def test_zpoppush_min_if_exists_3(self):
-        self._zadd('if_exists', {'a': 30})
+        self.conn.zadd('if_exists', {'a': 30})
         self._test_zpoppush_min_if_exists(20)
 
     def test_srem_if_not_exists_1(self):
@@ -292,7 +286,7 @@ class TestRedisScripts:
 
     def test_delete_if_not_in_zsets_1(self):
         self.conn.set('key', 0)
-        self._zadd('z2', {'other': 0})
+        self.conn.zadd('z2', {'other': 0})
         result = self.scripts.delete_if_not_in_zsets(
             'key', 'member', ['z1', 'z2']
         )
@@ -301,7 +295,7 @@ class TestRedisScripts:
 
     def test_delete_if_not_in_zsets_2(self):
         self.conn.set('key', 0)
-        self._zadd('z2', {'member': 0})
+        self.conn.zadd('z2', {'member': 0})
         result = self.scripts.delete_if_not_in_zsets(
             'key', 'member', ['z1', 'z2']
         )
@@ -310,12 +304,12 @@ class TestRedisScripts:
 
     def test_get_expired_tasks(self):
         self.conn.sadd('t:active', 'q1', 'q2', 'q3', 'q4')
-        self._zadd('t:active:q1', {'t1': 500})
-        self._zadd('t:active:q1', {'t2': 1000})
-        self._zadd('t:active:q1', {'t3': 1500})
-        self._zadd('t:active:q2', {'t4': 1200})
-        self._zadd('t:active:q3', {'t5': 1800})
-        self._zadd('t:active:q4', {'t6': 200})
+        self.conn.zadd('t:active:q1', {'t1': 500})
+        self.conn.zadd('t:active:q1', {'t2': 1000})
+        self.conn.zadd('t:active:q1', {'t3': 1500})
+        self.conn.zadd('t:active:q2', {'t4': 1200})
+        self.conn.zadd('t:active:q3', {'t5': 1800})
+        self.conn.zadd('t:active:q4', {'t6': 200})
 
         expired_task_set = {('q1', 't1'), ('q1', 't2'), ('q4', 't6')}
 
@@ -334,10 +328,7 @@ class TestRedisScripts:
         p.lpush('x', 'a')
         p.lpush('x', 'b')
         p.lrange('x', 0, -1)
-        if REDIS_PY_3:
-            p.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
-        else:
-            p.zadd('src', a=1, b=2, c=3, d=4)
+        p.zadd('src', {'a': 1, 'b': 2, 'c': 3, 'd': 4})
         # Ensure custom scripts work (ZPOPPUSH has both KEYS and ARGS)
         self.scripts.zpoppush('src', 'dst', 3, None, 10, client=p)
         # Ensure raw responses ('OK') are converted into Python values (True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,6 @@ import redis
 import structlog
 import time
 from tasktiger import TaskTiger, Worker, fixed
-from tasktiger._internal import REDIS_PY_3
 
 from .config import DELAY, TEST_DB, REDIS_HOST
 


### PR DESCRIPTION
Drop redis-py 2 support in preparation for the next version release, and the process to migrate from using the TaskTiger lock to using the lock offered by redis-py. Review only the last two commits, the first commit is from https://github.com/closeio/tasktiger/pull/182.