### PR TITLE
Clear retried executions from successful periodic tasks

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -274,16 +274,23 @@ class Task(object):
 
         if not to_state:  # Remove the task if necessary
             if self.unique:
-                # Only delete if it's not in any other queue
-                check_states = {ACTIVE, QUEUED, ERROR, SCHEDULED}
-                check_states.remove(from_state)
                 # TODO: Do the following two in one call.
+
+                # Delete executions if there were no errors.
+                if from_state == ERROR:
+                    check_states = {}
+                else:
+                    check_states = {ERROR}
                 scripts.delete_if_not_in_zsets(
                     _key('task', self.id, 'executions'),
                     self.id,
                     [_key(state, queue) for state in check_states],
                     client=pipeline,
                 )
+
+                # Only delete task if it's not in any other queue
+                check_states = {ACTIVE, QUEUED, ERROR, SCHEDULED}
+                check_states.remove(from_state)
                 scripts.delete_if_not_in_zsets(
                     _key('task', self.id),
                     self.id,


### PR DESCRIPTION
Previously, if you had a periodic task that retries up to N times for valid reasons, we would never clear the executions, so N would accumulate over the lifetime of a periodic task (forever). This PR doesn't completely fix the issue of tracking executions for previously failed periods, but at least it prevents executions from accumulating if the periodic task completes successfully after retries.