### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -183,7 +183,7 @@ class TaskTiger(object):
             # The following settings are only considered if no explicit queues
             # are passed in the command line (or to the queues argument in the
             # run_worker() method).
-            # If non-empty, a worker only processeses the given queues.
+            # If non-empty, a worker only processes the given queues.
             'ONLY_QUEUES': [],
             # If non-empty, a worker excludes the given queues from processing.
             'EXCLUDE_QUEUES': [],

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -279,7 +279,7 @@ class Worker(object):
         """
 
         # Note that we use the lock both to unnecessarily prevent multiple
-        # workers from requeueing expired tasks, as well as to space out
+        # workers from requeuing expired tasks, as well as to space out
         # this task (i.e. we don't release the lock unless we've exhausted our
         # batch size, which will hopefully never happen)
         lock = self.connection.lock(

--- a/tests/test_queue_size.py
+++ b/tests/test_queue_size.py
@@ -30,7 +30,7 @@ class TestMaxQueue(BaseTestCase):
         with pytest.raises(QueueFullException):
             self.tiger.delay(simple_task, queue='a', max_queue_size=1)
 
-        # Process first task and then queing a second should succeed
+        # Process first task and then queuing a second should succeed
         Worker(self.tiger).run(once=True, force_once=True)
         self.tiger.delay(simple_task, queue='a', max_queue_size=1)
         self._ensure_queues(queued={'a': 1})


### PR DESCRIPTION
There are small typos in:
- tasktiger/tasktiger.py
- tasktiger/worker.py
- tests/test_queue_size.py

Fixes:
- Should read `queuing` rather than `queing`.
- Should read `requeuing` rather than `requeueing`.
- Should read `processes` rather than `processeses`.

Closes #197