### PR TITLE
add github actions based ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+name: test-workflow
+on:
+  # When any branch in the repository is pushed
+  push:
+  # When a pull request is created
+  pull_request:
+  # When manually triggered to run
+  workflow_dispatch:
+
+jobs:
+  # Run tests
+  test:
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+        os: ['ubuntu-20.04']
+      # Do not cancel any jobs when a single job fails
+      fail-fast: false
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    container: python:${{ matrix.python-version }}
+    services:
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          pip install --requirement requirements.txt --requirement requirements-test.txt
+
+      - name: Run tests
+        run: pytest
+        env:
+          # The hostname used to communicate with the Redis service container
+          REDIS_HOST: redis

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,14 +14,15 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
         os: ['ubuntu-20.04']
+        redis-version: [4, 5, 6]
       # Do not cancel any jobs when a single job fails
       fail-fast: false
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with Redis ${{ matrix.redis-version }}
     runs-on: ${{ matrix.os }}
     container: python:${{ matrix.python-version }}
     services:
       redis:
-        image: redis
+        image: redis:${{ matrix.redis-version }}
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
@@ -31,6 +32,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Lint code
+        run: |
+          pip install black==21.7b0
+          black . --check
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR adds CI pipeline based on Github Actions.

Test are run in official python containers: python:3.6 through python:3.9.
A redis service container is provided for integration tests.