### PR TITLE
Add queue name to logs

### DIFF
--- a/tasktiger/logging.py
+++ b/tasktiger/logging.py
@@ -5,7 +5,7 @@ def tasktiger_processor(logger, method_name, event_dict):
     """
     TaskTiger structlog processor.
 
-    Inject the current task id for non-batch tasks.
+    Inject the current task ID and queue for non-batch tasks.
     """
 
     if g['current_tasks'] is not None and not g['current_task_is_batch']:

--- a/tasktiger/logging.py
+++ b/tasktiger/logging.py
@@ -9,6 +9,8 @@ def tasktiger_processor(logger, method_name, event_dict):
     """
 
     if g['current_tasks'] is not None and not g['current_task_is_batch']:
-        event_dict['task_id'] = g['current_tasks'][0].id
+        current_task = g['current_tasks'][0]
+        event_dict['task_id'] = current_task.id
+        event_dict['queue'] = current_task.queue
 
     return event_dict

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -16,7 +16,7 @@ logger = structlog.getLogger("tasktiger")
 
 def logging_task():
     log = logger.info("simple task")
-    # Confirm tasktiger_processor injected task id
+    # Confirm tasktiger_processor injected task id and queue name
     assert log[1]["task_id"] == tiger.current_task.id
     assert log[1]["queue"] == tiger.current_task.queue
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,6 +18,7 @@ def logging_task():
     log = logger.info("simple task")
     # Confirm tasktiger_processor injected task id
     assert log[1]["task_id"] == tiger.current_task.id
+    assert log[1]["queue"] == tiger.current_task.queue
 
 
 class TestLogging(BaseTestCase):


### PR DESCRIPTION
Log queue name of the current task from the default structlog processor.