### PR TITLE
Add function name to tasktiger done log messages

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -959,7 +959,9 @@ class Worker(object):
         the task gets properly removed from the ACTIVE queue and, in case of an
         error, retried or marked as failed.
         """
-        log = self.log.bind(queue=queue, task_id=task.id)
+        log = self.log.bind(
+            queue=queue, func=task.serialized_func, task_id=task.id
+        )
 
         now = time.time()
         processing_duration = now - start_time


### PR DESCRIPTION
This is useful when trying to run aggregations based on log messages. Currently there's no way to see something like an average `processing_duration` per function because func name isn't included in the log message.