### PR TITLE
Bump python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.6
       - test-3.7
       - test-3.8
+      - test-3.9
+      - test-3.10
       - black
 
 defaults: &defaults
@@ -24,11 +25,6 @@ defaults: &defaults
       command: pytest
 
 jobs:
-  test-3.6:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.6
-    - image: redis:4.0.6
   test-3.7:
     <<: *defaults
     docker:
@@ -39,10 +35,20 @@ jobs:
     docker:
     - image: circleci/python:3.8
     - image: redis:4.0.6
+  test-3.9:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.9
+      - image: redis:4.0.6
+  test-3.10:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.10
+      - image: redis:4.0.6
   black:
     working_directory: ~/code
     docker:
-    - image: circleci/python:3.6
+    - image: circleci/python:3.8
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ workflows:
       - test-3.7
       - test-3.8
       - test-3.9
-      - test-3.10
       - black
 
 defaults: &defaults
@@ -39,11 +38,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/python:3.9
-      - image: redis:4.0.6
-  test-3.10:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.10
       - image: redis:4.0.6
   black:
     working_directory: ~/code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
         os: ['ubuntu-20.04']
         redis-version: [4, 5, 6]
       # Do not cancel any jobs when a single job fails

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.6
+FROM circleci/python:3.8
 
 WORKDIR /src
 COPY requirements.txt .


### PR DESCRIPTION
drop 3.6 where it's mentioned (in the docker image + circleci testing), add 3.9 to circleci