### PR TITLE
Add task args / kwargs to the task_error log statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: sudo pip install black==19.10b0 regex==2019.11.1
+          command: sudo pip install black==19.10b0 regex==2019.11.1 click<8.1
       - run:
           name: Check formatting
           command: black --check .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: sudo pip install black==19.10b0 regex==2019.11.1 click<8.1
+          command: sudo pip install black==19.10b0 regex==2019.11.1 "click<8.1"
       - run:
           name: Check formatting
           command: black --check .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Lint code
         run: |
-          pip install black==21.7b0
+          pip install black==21.7b0 click<8.1
           black . --check
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Lint code
         run: |
-          pip install black==21.7b0 click<8.1
+          pip install black==21.7b0 "click<8.1"
           black . --check
 
       - name: Install dependencies

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -1053,6 +1053,8 @@ class Worker(object):
 
                 log_context.update(
                     {
+                        "task_args": task.args,
+                        "task_kwars": task.kwargs,
                         "time_failed": execution.get("time_failed"),
                         "traceback": execution.get("traceback"),
                         "exception_name": execution.get("exception_name"),

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -1054,7 +1054,7 @@ class Worker(object):
                 log_context.update(
                     {
                         "task_args": task.args,
-                        "task_kwars": task.kwargs,
+                        "task_kwargs": task.kwargs,
                         "time_failed": execution.get("time_failed"),
                         "traceback": execution.get("traceback"),
                         "exception_name": execution.get("exception_name"),


### PR DESCRIPTION
These are useful to log as well and can often save us some time instead of having to look up args/kwargs by searching logs for the task id.

I've also pinned the version of `click` installed with `black` to prevent a regression in the most recent version. We can drop it once `black` is updated to either not use the deprecated functionality or to pin the older version in its requirements.