### PR TITLE
Pin redis for GH actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: ['ubuntu-20.04']
-        redis-version: [4, 5, 6]
+        redis-version: [4, 5, "6.2.6"]
       # Do not cancel any jobs when a single job fails
       fail-fast: false
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with Redis ${{ matrix.redis-version }}


### PR DESCRIPTION
I'm still not sure what broke in redis 6.2.7 ([changelog](https://github.com/redis/redis/releases/tag/6.2.7)), could be related to the Lua scripts.

In the meantime, I pinned the version of redis targeted by our tests running in Github Actions.