### PR TITLE
Prefilter polled queues

### DIFF
--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -24,7 +24,7 @@ from .task import Task
 from .timeouts import JobTimeoutException
 
 LOCK_REDIS_KEY = "qslock"
-REDIS_GLOB_CHARACTER_PATTERN = re.compile(r"([?*\[\]])")
+REDIS_GLOB_CHARACTER_PATTERN = re.compile(r"([\\?*\[\]])")
 
 __all__ = ["Worker"]
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -742,14 +742,14 @@ class TestCase(BaseTestCase):
     @pytest.mark.parametrize(
         "only_queues,expected_unprocessed",
         [
-            (["a"], {"b": 1, "b.a": 1, "[ab]*?": 2}),
-            (["a", "b"], {"[ab]*?": 2}),
-            (["a", "[ab]*?"], {"b": 1, "b.a": 1}),
+            (["a"], {"b": 1, "b.a": 1, "[ab\\c]*?": 2}),
+            (["a", "b"], {"[ab\\c]*?": 2}),
+            (["a", "[ab\\c]*?"], {"b": 1, "b.a": 1}),
             # tests that queue prefiltering works correctly with queues
             # containing special characters used in Redis glob patterns
-            (["[ab]*?"], {"a": 1, "a.a": 1, "b": 1, "b.a": 1}),
+            (["[ab\\c]*?"], {"a": 1, "a.a": 1, "b": 1, "b.a": 1}),
             # all queues selected, all queues processed
-            (["a", "b", "[ab]*?"], {}),
+            (["a", "b", "[ab\\c]*?"], {}),
             # no queue restriction, all queues processed
             ([], {}),
         ],
@@ -759,11 +759,11 @@ class TestCase(BaseTestCase):
         self.tiger.delay(simple_task, queue="a.a")
         self.tiger.delay(simple_task, queue="b")
         self.tiger.delay(simple_task, queue="b.a")
-        self.tiger.delay(simple_task, queue="[ab]*?")
-        self.tiger.delay(simple_task, queue="[ab]*?")
+        self.tiger.delay(simple_task, queue="[ab\\c]*?")
+        self.tiger.delay(simple_task, queue="[ab\\c]*?")
 
         self._ensure_queues(
-            queued={"a": 1, "a.a": 1, "b": 1, "b.a": 1, "[ab]*?": 2}
+            queued={"a": 1, "a.a": 1, "b": 1, "b.a": 1, "[ab\\c]*?": 2}
         )
 
         self.tiger.config["ONLY_QUEUES"] = only_queues


### PR DESCRIPTION
This is a PoC for reducing the Redis load caused by each worker frequently polling the entire set of subqueues.

SSCAN lets us prefilter the queues we pull out of Redis, and seems pretty fast too:
```py
production In [49]: r.scard("t:scheduled")
production Out[49]: 3919

production In [50]: timeit.timeit(lambda: r.smembers("t:scheduled"), number=5)
production Out[50]: 0.06490249998751096

production In [51]: timeit.timeit(lambda: r.sscan("t:scheduled", match="zoom.*", count=10000), number=5)
production Out[51]: 0.01752800800022669
```