### PR TITLE
Sort imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,15 @@ exclude = '''
     \.git
 )/
 '''
+
+[tool.isort]
+skip = ['.git', 'venv']
+known_tests = ['tests']
+sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'TESTS', 'LOCALFOLDER']
+default_section = 'THIRDPARTY'
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+multi_line_output = 3
+line_length = 78
+float_to_top = true

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import absolute_import
 
+from ._internal import *
+from .exceptions import *
+from .retry import *
+from .schedule import *
+from .task import Task
+from .tasktiger import TaskTiger, run_worker
+from .worker import Worker
+
 __all__ = [
     "TaskTiger",
     "Worker",
@@ -17,14 +25,6 @@ __all__ = [
     # Schedules
     "periodic",
 ]
-
-from ._internal import *
-from .exceptions import *
-from .retry import *
-from .schedule import *
-from .task import Task
-from .tasktiger import TaskTiger, run_worker
-from .worker import Worker
 
 
 if __name__ == "__main__":

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -1,8 +1,8 @@
 import binascii
 import calendar
 import datetime
-import importlib
 import hashlib
+import importlib
 import json
 import operator
 import os

--- a/tasktiger/flask_script.py
+++ b/tasktiger/flask_script.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import argparse
+
 from flask_script import Command
 
 

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -1,6 +1,5 @@
 import os
 
-
 # ARGV = { score, member }
 ZADD_NOUPDATE_TEMPLATE = """
     if {condition} redis.call('zscore', {key}, {member}) then

--- a/tasktiger/rollbar.py
+++ b/tasktiger/rollbar.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import json
+
 import rollbar
 from rollbar.logger import RollbarHandler
 

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -1,8 +1,9 @@
 import copy
 import datetime
 import json
-import redis
 import time
+
+import redis
 
 from ._internal import *
 from .exceptions import QueueFullException, TaskImportError, TaskNotFound

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -1,31 +1,31 @@
 from __future__ import absolute_import
 
-__all__ = ["TaskTiger"]
-
-from collections import defaultdict
-import click
 import datetime
 import importlib
 import logging
+from collections import defaultdict
+
+import click
 import redis
 import structlog
 
-from .redis_semaphore import Semaphore
-from .redis_scripts import RedisScripts
-
 from ._internal import (
-    classproperty,
-    g,
-    serialize_func_name,
-    QUEUED,
-    SCHEDULED,
     ACTIVE,
     ERROR,
+    QUEUED,
+    SCHEDULED,
+    classproperty,
+    g,
     queue_matches,
+    serialize_func_name,
 )
+from .redis_scripts import RedisScripts
+from .redis_semaphore import Semaphore
 from .retry import fixed
 from .task import Task
 from .worker import LOCK_REDIS_KEY, Worker
+
+__all__ = ["TaskTiger"]
 
 
 """

--- a/tasktiger/test_helpers.py
+++ b/tasktiger/test_helpers.py
@@ -1,7 +1,6 @@
 from .task import Task
 from .worker import Worker
 
-
 __all__ = ["TaskTigerTestMixin"]
 
 

--- a/tasktiger/timeouts.py
+++ b/tasktiger/timeouts.py
@@ -5,6 +5,7 @@ from __future__ import (
     print_function,
     unicode_literals,
 )
+
 import signal
 
 from .exceptions import JobTimeoutException

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-from contextlib import ExitStack
 import errno
 import fcntl
 import random
@@ -10,6 +8,8 @@ import sys
 import time
 import traceback
 import uuid
+from collections import OrderedDict
+from contextlib import ExitStack
 
 from redis.exceptions import LockError
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,6 +1,6 @@
 import json
-from math import ceil
 import time
+from math import ceil
 
 import redis
 
@@ -8,9 +8,8 @@ from tasktiger import RetryException, TaskTiger
 from tasktiger.retry import fixed
 from tasktiger.runner import BaseRunner, DefaultRunner
 
-from .config import DELAY, TEST_DB, REDIS_HOST
+from .config import DELAY, REDIS_HOST, TEST_DB
 from .utils import get_tiger
-
 
 LONG_TASK_SIGNAL_KEY = "long_task_ok"
 

--- a/tests/tasks_periodic.py
+++ b/tests/tasks_periodic.py
@@ -4,7 +4,7 @@ import redis
 
 from tasktiger.schedule import periodic
 
-from .config import TEST_DB, REDIS_HOST
+from .config import REDIS_HOST, TEST_DB
 from .utils import get_tiger
 
 tiger = get_tiger()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,13 +1,13 @@
 import datetime
 import json
 import os
-import pytest
 import signal
 import sys
 import tempfile
 import time
 from multiprocessing import Pool, Process
 
+import pytest
 from freezefrog import FreezeTime
 
 from tasktiger import (
@@ -24,6 +24,9 @@ from tasktiger._internal import serialize_func_name
 
 from .config import DELAY
 from .tasks import (
+    MyErrorRunnerClass,
+    MyRunnerClass,
+    StaticTask,
     batch_task,
     decorated_task,
     decorated_task_simple_func,
@@ -33,18 +36,15 @@ from .tasks import (
     locked_task,
     long_task_killed,
     long_task_ok,
-    MyErrorRunnerClass,
-    MyRunnerClass,
     non_batch_task,
     retry_task,
     retry_task_2,
     simple_task,
     sleep_task,
-    StaticTask,
     task_on_other_queue,
-    unique_task,
     unique_exception_task,
     unique_key_task,
+    unique_task,
     verify_current_task,
     verify_current_tasks,
     verify_tasktiger_instance,

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -3,9 +3,9 @@ import redis
 
 from tasktiger import Worker
 
+from .config import REDIS_HOST, TEST_DB
 from .tasks import exception_task, simple_task
 from .test_base import BaseTestCase
-from .config import TEST_DB, REDIS_HOST
 
 
 class ContextManagerTester(object):

--- a/tests/test_lazy_init.py
+++ b/tests/test_lazy_init.py
@@ -4,7 +4,8 @@ import logging
 import tempfile
 
 from tasktiger import TaskTiger, Worker
-from tests.utils import setup_structlog, get_redis, TEST_TIGER_CONFIG
+
+from tests.utils import TEST_TIGER_CONFIG, get_redis, setup_structlog
 
 tiger = TaskTiger(lazy_init=True)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,8 +6,7 @@ from tasktiger import TaskTiger, Worker
 from tasktiger.logging import tasktiger_processor
 
 from .test_base import BaseTestCase
-from .utils import get_tiger, get_redis
-
+from .utils import get_redis, get_tiger
 
 tiger = get_tiger()
 

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -3,16 +3,17 @@
 import datetime
 import time
 
-from tasktiger import Worker, periodic
 from tasktiger import (
-    Task,
-    gen_unique_id,
-    serialize_func_name,
     QUEUED,
     SCHEDULED,
+    Task,
+    Worker,
+    gen_unique_id,
+    periodic,
+    serialize_func_name,
 )
 
-from .tasks_periodic import tiger, periodic_task
+from .tasks_periodic import periodic_task, tiger
 from .test_base import BaseTestCase
 from .utils import sleep_until_next_second
 

--- a/tests/test_queue_size.py
+++ b/tests/test_queue_size.py
@@ -1,10 +1,10 @@
 """Test max queue size limits."""
 
-from multiprocessing import Process
 import datetime
 import os
 import signal
 import time
+from multiprocessing import Process
 
 import pytest
 

--- a/tests/test_semaphore.py
+++ b/tests/test_semaphore.py
@@ -2,11 +2,11 @@
 import datetime
 import time
 
+import pytest
 from freezefrog import FreezeTime
 
-import pytest
-
 from tasktiger.redis_semaphore import Semaphore
+
 from .utils import get_tiger
 
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,8 +1,8 @@
 """Test workers."""
 
 import datetime
-from multiprocessing import Process
 import time
+from multiprocessing import Process
 
 from freezefrog import FreezeTime
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,13 @@
 import datetime
 import logging
+import time
+
 import redis
 import structlog
-import time
+
 from tasktiger import TaskTiger, Worker, fixed
 
-from .config import DELAY, TEST_DB, REDIS_HOST
+from .config import DELAY, REDIS_HOST, TEST_DB
 
 TEST_TIGER_CONFIG = {
     # We need this 0 here so we don't pick up scheduled tasks when


### PR DESCRIPTION
I noticed there's no linting other than `black` in CI. We might want to gradually start adding it so we could eventually start using `lintlizard`.