### PR TITLE
Add task execution counter

### DIFF
--- a/tasktiger/migrations.py
+++ b/tasktiger/migrations.py
@@ -1,3 +1,6 @@
+from .utils import redis_glob_escape
+
+
 def migrate_executions_count(tiger):
     """
     Backfills ``t:task:<uuid>:executions_count`` by counting
@@ -13,8 +16,9 @@ def migrate_executions_count(tiger):
         """
     )
 
-    for key in tiger.connection.scan_iter(
-        count=100, match="*:task:*:executions"
-    ):
-        if key.startswith(tiger.config["REDIS_PREFIX"] + ":task:"):
-            migrate_task(keys=[key, key + "_count"])
+    match = (
+        redis_glob_escape(tiger.config["REDIS_PREFIX"]) + ":task:*:executions"
+    )
+
+    for key in tiger.connection.scan_iter(count=100, match=match):
+        migrate_task(keys=[key, key + "_count"])

--- a/tasktiger/migrations.py
+++ b/tasktiger/migrations.py
@@ -1,0 +1,20 @@
+def migrate_executions_count(tiger):
+    """
+    Backfills ``t:task:<uuid>:executions_count`` by counting
+    elements in ``t:task:<uuid>:executions``.
+    """
+
+    migrate_task = tiger.connection.register_script(
+        """
+        local count = redis.call('llen', KEYS[1])
+        if tonumber(redis.call('get', KEYS[2]) or 0) < count then
+            redis.call('set', KEYS[2], count)
+        end
+        """
+    )
+
+    for key in tiger.connection.scan_iter(
+        count=100, match="*:task:*:executions"
+    ):
+        if key.startswith(tiger.config["REDIS_PREFIX"] + ":task:"):
+            migrate_task(keys=[key, key + "_count"])

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -40,8 +40,12 @@ SET <prefix>:scheduled
 Serialized task for the given task ID.
 STRING <prefix>:task:<task_id>
 
-List of (failed) task executions
+List of (failed) task executions. The oldest entries
+could be truncated depending on the task parameters.
 LIST <prefix>:task:<task_id>:executions
+
+The total number of times a task was executed.
+STRING <prefix>:task:<task_id>:executions_count
 
 Task IDs waiting in the given queue to be processed, scored by the time the
 task was queued.

--- a/tasktiger/utils.py
+++ b/tasktiger/utils.py
@@ -1,0 +1,7 @@
+import re
+
+REDIS_GLOB_CHARACTER_PATTERN = re.compile(r"([\\?*\[\]])")
+
+
+def redis_glob_escape(value):
+    return REDIS_GLOB_CHARACTER_PATTERN.sub(r"\\\1", value)

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -22,9 +22,9 @@ from .runner import get_runner_class
 from .stats import StatsThread
 from .task import Task
 from .timeouts import JobTimeoutException
+from .utils import redis_glob_escape
 
 LOCK_REDIS_KEY = "qslock"
-REDIS_GLOB_CHARACTER_PATTERN = re.compile(r"([\\?*\[\]])")
 
 __all__ = ["Worker"]
 
@@ -1158,12 +1158,7 @@ class Worker(object):
             return self.connection.smembers(key)
 
         # Escape special Redis glob characters in the queue name
-        match = (
-            REDIS_GLOB_CHARACTER_PATTERN.sub(
-                r"\\\1", list(self.only_queues)[0]
-            )
-            + "*"
-        )
+        match = redis_glob_escape(list(self.only_queues)[0]) + "*"
 
         return set(self.connection.sscan_iter(key, match=match, count=100000))
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,79 @@
+import uuid
+
+import pytest
+
+from tasktiger.migrations import migrate_executions_count
+
+from .test_base import BaseTestCase
+
+
+class TestMigrateExecutionsCount(BaseTestCase):
+    def test_migrate_nothing(self):
+        migrate_executions_count(self.tiger)
+        assert self.conn.keys() == []
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            f"foot:task:{uuid.uuid4()}:executions",
+            f"foo:t:task:{uuid.uuid4()}:executions",
+            f"t:task:{uuid.uuid4()}:executionsfoo",
+            f"t:task:{uuid.uuid4()}:executions:foo",
+            f"t:task:{uuid.uuid4()}",
+        ],
+    )
+    def test_migrate_ignores_irrelevant_keys(self, key):
+        self.conn.rpush(key, "{}")
+        migrate_executions_count(self.tiger)
+
+        assert self.conn.keys() == [key]
+
+    def test_migrate(self):
+        task_id_1 = uuid.uuid4()
+        task_id_2 = uuid.uuid4()
+
+        for __ in range(73):
+            self.conn.rpush(f"t:task:{task_id_1}:executions", "{}")
+
+        for __ in range(35):
+            self.conn.rpush(f"t:task:{task_id_2}:executions", "{}")
+
+        migrate_executions_count(self.tiger)
+        assert self.conn.get(f"t:task:{task_id_1}:executions_count") == "73"
+        assert self.conn.get(f"t:task:{task_id_2}:executions_count") == "35"
+
+    def test_migrate_when_some_tasks_already_migrated(self):
+        task_id_1 = uuid.uuid4()
+        task_id_2 = uuid.uuid4()
+
+        for __ in range(73):
+            self.conn.rpush(f"t:task:{task_id_1}:executions", "{}")
+
+        self.conn.set(f"t:task:{task_id_1}:executions_count", 91)
+
+        for __ in range(35):
+            self.conn.rpush(f"t:task:{task_id_2}:executions", "{}")
+
+        migrate_executions_count(self.tiger)
+        assert self.conn.get(f"t:task:{task_id_2}:executions_count") == "35"
+
+        # looks migrated already - left untouched
+        assert self.conn.get(f"t:task:{task_id_1}:executions_count") == "91"
+
+    def test_migrate_when_counter_is_behind(self):
+        task_id_1 = uuid.uuid4()
+        task_id_2 = uuid.uuid4()
+
+        for __ in range(73):
+            self.conn.rpush(f"t:task:{task_id_1}:executions", "{}")
+
+        self.conn.set(f"t:task:{task_id_1}:executions_count", 10)
+
+        for __ in range(35):
+            self.conn.rpush(f"t:task:{task_id_2}:executions", "{}")
+
+        migrate_executions_count(self.tiger)
+        assert self.conn.get(f"t:task:{task_id_2}:executions_count") == "35"
+
+        # updated because the counter value was less than the actual count
+        assert self.conn.get(f"t:task:{task_id_1}:executions_count") == "73"

--- a/tests/test_redis_scripts.py
+++ b/tests/test_redis_scripts.py
@@ -285,22 +285,43 @@ class TestRedisScripts:
         assert self.conn.smembers("set") == {"member"}
 
     def test_delete_if_not_in_zsets_1(self):
-        self.conn.set("key", 0)
+        self.conn.set("foo", 0)
+        self.conn.set("bar", 0)
+        self.conn.set("baz", 0)
+
         self.conn.zadd("z2", {"other": 0})
         result = self.scripts.delete_if_not_in_zsets(
-            "key", "member", ["z1", "z2"]
+            to_delete=["foo", "bar"], value="member", zsets=["z1", "z2"]
         )
-        assert result == 1
-        assert self.conn.exists("key") == 0
+        assert result == 2
+        assert self.conn.exists("foo") == 0
+        assert self.conn.exists("bar") == 0
+        assert self.conn.exists("baz") == 1
+        assert self.conn.exists("z2") == 1
 
     def test_delete_if_not_in_zsets_2(self):
-        self.conn.set("key", 0)
+        self.conn.set("foo", 0)
+        self.conn.set("bar", 0)
+
         self.conn.zadd("z2", {"member": 0})
         result = self.scripts.delete_if_not_in_zsets(
-            "key", "member", ["z1", "z2"]
+            to_delete=["foo", "bar"], value="member", zsets=["z1", "z2"]
         )
         assert result == 0
-        assert self.conn.exists("key") == 1
+        assert self.conn.exists("foo") == 1
+        assert self.conn.exists("bar") == 1
+        assert self.conn.exists("z2") == 1
+
+    def test_delete_if_not_in_zsets_3(self):
+        self.conn.set("foo", 0)
+        self.conn.set("bar", 0)
+
+        result = self.scripts.delete_if_not_in_zsets(
+            to_delete=["foo", "bar"], value="member", zsets=[]
+        )
+        assert result == 2
+        assert self.conn.exists("foo") == 0
+        assert self.conn.exists("bar") == 0
 
     def test_get_expired_tasks(self):
         self.conn.sadd("t:active", "q1", "q2", "q3", "q4")


### PR DESCRIPTION
Introduces a task execution counter that's meant to be used instead of counting the number of executions using Redis `LLEN`.

This is the first step towards being able to truncate the list of executions.