### PR TITLE
[PoC] Queue notification to optimize polling

### DIFF
--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -345,7 +345,7 @@ class Task:
         )
 
         if to_state == QUEUED:
-            self.tiger._notify_queue(queue, client=pipeline)
+            self.tiger._notify_task_queued(queue, client=pipeline)
 
         try:
             scripts.execute_pipeline(pipeline)
@@ -422,7 +422,7 @@ class Task:
         )
 
         if state == QUEUED:
-            tiger._notify_queue(self.queue, client=pipeline)
+            tiger._notify_task_queued(self.queue, client=pipeline)
 
         pipeline.execute()
 

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -265,7 +265,7 @@ class TaskTiger:
     current_task = property(_get_current_task)
     current_tasks = property(_get_current_tasks)
 
-    def _notify_queue(self, queue, client=None):
+    def _notify_task_queued(self, queue, client=None):
         _client = client or self.connection.pipeline(transaction=False)
 
         if self.config["PUBLISH_QUEUED_TASKS"]:
@@ -275,7 +275,7 @@ class TaskTiger:
         if cache_token_expiry > 0:
             for queue_part in list(dotted_parts(queue)) + [""]:
                 _client.set(
-                    self._key("queue_cache_token", queue_part),
+                    self._key("queued_cache_token", queue_part),
                     secrets.token_hex(),
                     ex=cache_token_expiry,
                 )

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -87,7 +87,7 @@ class Worker:
         self._did_work = True
         self._last_task_check = 0.0
         self._next_forced_queue_poll = 0.0
-        self._queue_cache_tokens: Optional[Tuple[Optional[str], ...]] = None
+        self._queued_cache_tokens: Optional[Tuple[Optional[str], ...]] = None
         self.stats_thread = None
         self.id = str(uuid.uuid4())
 
@@ -223,7 +223,7 @@ class Worker:
             # XXX: ideally this would be in the same pipeline, but we only want
             # to announce if there was a result.
             if result:
-                self.tiger._notify_queue(queue)
+                self.tiger._notify_task_queued(queue)
                 self._did_work = True
 
     def _poll_for_queues(self) -> None:
@@ -248,9 +248,9 @@ class Worker:
         next_forced_queue_poll = self._next_forced_queue_poll
         self._next_forced_queue_poll = time.monotonic() + cache_token_expiry
 
-        queue_cache_tokens = self._get_queue_cache_tokens()
-        if queue_cache_tokens != self._queue_cache_tokens:
-            self._queue_cache_tokens = queue_cache_tokens
+        queued_cache_tokens = self._get_queued_cache_tokens()
+        if queued_cache_tokens != self._queued_cache_tokens:
+            self._queued_cache_tokens = queued_cache_tokens
             return True
 
         # Ensure that we poll queues when we haven't retrieved the cache
@@ -261,9 +261,9 @@ class Worker:
 
         return False
 
-    def _get_queue_cache_tokens(self) -> Tuple[Optional[str], ...]:
+    def _get_queued_cache_tokens(self) -> Tuple[Optional[str], ...]:
         keys = sorted(
-            self._key("queue_cache_token", queue)
+            self._key("queued_cache_token", queue)
             for queue in self.only_queues or [""]
         )
 


### PR DESCRIPTION
This PR is a PoC for an optimised way to poll queues. Tests were deliberately omitted at this stage.

The way it works is that the key `t:queued_cache_token:<queue root>` (I welcome better naming here)  is updated with a random token whenever a task is added to that queue.

The workers will monitor the tokens related to the queues they're interested in and do the expensive queue poll only when any of them change (or if an hour elapsed since the last poll, as a safeguard).
