### PR TITLE
Deprecate Flask-Script integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -564,28 +564,6 @@ TaskTiger worker and parses any command line arguments. Here is an example:
       tiger.run_worker_with_args(sys.argv[2:])
       sys.exit(0)
 
-If you're using ``flask-script``, you can use the ``TaskTigerCommand`` provided
-in the ``tasktiger.flask_script`` module. It takes the ``TaskTiger`` instance
-as an argument. Tasks will have access to Flask's application context. Example:
-
-.. code:: python
-
-  from flask import Flask
-  from flask.ext.script import Manager
-  from tasktiger.flask_script import TaskTigerCommand
-
-  app = Flask()
-  manager = Manager(app)
-  tiger = TaskTiger(setup_structlog=True)
-
-  manager.add_command('tasktiger', TaskTigerCommand(tiger))
-
-  if __name__ == "__main__":
-      manager.run()
-
-You can subclass the ``TaskTigerCommand`` and override the ``setup`` method to
-implement any custom setup that needs to be done before running the worker.
-
 
 Inspect, requeue and delete tasks
 ---------------------------------

--- a/tasktiger/flask_script.py
+++ b/tasktiger/flask_script.py
@@ -6,6 +6,11 @@ from flask_script import Command
 
 
 class TaskTigerCommand(Command):
+    """
+    This class is deprecated and may be removed in future versions.
+    That is because Flask-Script is no longer supported (since 2017).
+    """
+
     capture_all_args = True
     help = "Run a TaskTiger worker"
 


### PR DESCRIPTION
Flask-Script is no longer supported so we might not want to get rid of the integration at some point in the future.