### PR TITLE
docs: remove secret from public repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 =========
 TaskTiger
 =========
-.. image:: https://circleci.com/gh/closeio/tasktiger/tree/master.svg?style=svg&circle-token=a86617952aa9b4cfee784b6ac43358cd042a6672
+.. image:: https://circleci.com/gh/closeio/tasktiger/tree/master.svg?style=svg
     :target: https://circleci.com/gh/closeio/tasktiger/tree/master
 
 *TaskTiger* is a Python task queue using Redis.


### PR DESCRIPTION
Looks like token is no longer valid, however it's been in the codebase for 8 years. Not sure when repo went public, but best to remove and fix the status badge not displaying correctly anyway.