### PR TITLE
add tiger.current_serialized_func

### DIFF
--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -272,12 +272,18 @@ class TaskTiger:
             raise RuntimeError("Must use current_task in a non-batch task.")
         return g["current_tasks"]
 
+    def _get_current_serialized_func(self) -> str:
+        if g["current_tasks"] is None:
+            raise RuntimeError("Must be accessed from within a task.")
+        return g["current_tasks"][0].serialized_func
+
     """
     Properties to access the currently processing task (or tasks, in case of a
     batch task) from within the task. They must be invoked from within a task.
     """
     current_task = property(_get_current_task)
     current_tasks = property(_get_current_tasks)
+    current_serialized_func = property(_get_current_serialized_func)
 
     @classproperty
     def current_instance(self) -> "TaskTiger":

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -157,6 +157,23 @@ def verify_current_tasks(tasks):
             conn.rpush("task_ids", *[t.id for t in tasks])
 
 
+def verify_current_serialized_func():
+    with redis.Redis(
+        host=REDIS_HOST, db=TEST_DB, decode_responses=True
+    ) as conn:
+        serialized_func = tiger.current_serialized_func
+        conn.set("serialized_func", serialized_func)
+
+
+@tiger.task(batch=True, queue="batch")
+def verify_current_serialized_func_batch(tasks):
+    with redis.Redis(
+        host=REDIS_HOST, db=TEST_DB, decode_responses=True
+    ) as conn:
+        serialized_func = tiger.current_serialized_func
+        conn.set("serialized_func", serialized_func)
+
+
 @tiger.task()
 def verify_tasktiger_instance():
     # Not necessarily the same object, but the same configuration.


### PR DESCRIPTION
Adds a `current_serialized_func` property to the `tiger` object.

This is useful for instrumentation - the `current_serialized_func` can be used for naming spans or labeling metrics.

Without it one would have to do e.g.

```python
try:
    return tiger.current_task.serialized_func
except RuntimeError:
    return tiger.current_tasks[0].serialized_func
```

because we don't expose `current_task_is_batch` either.