### PR TITLE
Purge errored tasks even if task object is not found

### DIFF
--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -611,7 +611,12 @@ class TaskTiger:
                 task_limit = 5000
                 while total_tasks is None or skip < total_tasks:
                     total_tasks, tasks = Task.tasks_from_queue(
-                        self, queue, ERROR, skip=skip, limit=task_limit
+                        self,
+                        queue,
+                        ERROR,
+                        skip=skip,
+                        limit=task_limit,
+                        include_not_found=True,
                     )
                     for task in tasks:
                         if (

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -965,6 +965,17 @@ class TestCase(BaseTestCase):
         assert 1 == self.tiger.purge_errored_tasks()
         self._ensure_queues(queued={"default": 1}, error={"default": 0})
 
+    def test_purge_errored_tasks_if_task_not_found(self):
+        task = self.tiger.delay(exception_task)
+
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(error={"default": 1})
+
+        self.tiger.connection.delete(self.tiger._key("task", task.id))
+
+        self.tiger.purge_errored_tasks()
+        self._ensure_queues(error={"default": 0})
+
 
 class TestTasks(BaseTestCase):
     """


### PR DESCRIPTION
Would still be nice to find the root cause though.

It behaves just like before (by failing) if the `include_not_found` flag is not given.