### PR TITLE
Task lock should be non-local

### DIFF
--- a/tasktiger/executor.py
+++ b/tasktiger/executor.py
@@ -403,9 +403,11 @@ class SyncExecutor(Executor):
         queue_lock: Optional[Semaphore],
         stop_event: threading.Event,
     ) -> None:
-        while not stop_event.is_set():
-            stop_event.wait(self.config["ACTIVE_TASK_UPDATE_TIMER"])
-            self.heartbeat(queue, task_ids, log, locks, queue_lock)
+        while not stop_event.wait(self.config["ACTIVE_TASK_UPDATE_TIMER"]):
+            try:
+                self.heartbeat(queue, task_ids, log, locks, queue_lock)
+            except Exception:
+                log.exception("task heartbeat failed")
 
     def execute(
         self,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -674,6 +674,8 @@ class Worker:
                     lock = self.connection.lock(
                         self._key("lockv2", lock_id),
                         timeout=self.config["ACTIVE_TASK_UPDATE_TIMEOUT"],
+                        # Sync worker uses a thread to renew the lock.
+                        thread_local=False,
                     )
                     if not lock.acquire(blocking=False):
                         log.info("could not acquire lock", task_id=task.id)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -188,7 +188,8 @@ class TestSyncExecutorWorker:
         ensure_queues(error={"default": 1})
 
     def test_heartbeat(self, tiger):
-        task = Task(tiger, sleep_task)
+        # Test both task heartbeat and lock renewal.
+        task = Task(tiger, sleep_task, lock=True)
         task.delay()
 
         # Start a worker and wait until it starts processing.
@@ -196,7 +197,11 @@ class TestSyncExecutorWorker:
             target=external_worker,
             kwargs={
                 "patch_config": {"ACTIVE_TASK_UPDATE_TIMER": DELAY / 2},
-                "worker_kwargs": {"executor_class": SyncExecutor},
+                "worker_kwargs": {
+                    # Test queue lock.
+                    "max_workers_per_queue": 1,
+                    "executor_class": SyncExecutor,
+                },
             },
         )
         worker.start()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -206,7 +206,7 @@ class TestSyncExecutorWorker:
         )
         worker.start()
 
-        time.sleep(DELAY / 2)
+        time.sleep(DELAY)
 
         key = tiger._key(ACTIVE, "default")
         conn = tiger.connection


### PR DESCRIPTION
Analyzing the thread safety of the heartbeat function in the sync executor:
- Redis-py should by threadsafe by default unless `single_connection_client` is given, which is false by default.
- When doing a `heartbeat()` we update the task timestamp, renew any task locks and any queue lock.
- The queue lock ([`Semaphore`](https://github.com/closeio/tasktiger/blob/master/tasktiger/redis_semaphore.py)) does not care about threads so we can therefore renew it from a different thread.
- Redis locks, which we use for locking tasks, are thread-local by default, we therefore need to set `thread_local=False`.
- We use Redis locks in a couple other places but these are not being accessed by the heartbeat thread.

Also:
- Improved heartbeat so we don't need to do a heartbeat if the task already completed after the wait, and added exception handling.
- Fixed test to give it a bit more time to start (had some failures locally) + have at least one task & queue lock that should be renewed.