### PR TITLE
Stop heartbeat thread in case of unhandled exceptions.

### DIFF
--- a/tasktiger/executor.py
+++ b/tasktiger/executor.py
@@ -434,10 +434,13 @@ class SyncExecutor(Executor):
         heartbeat_thread.start()
 
         # Run the tasks.
-        result = self.execute_tasks(tasks, log)
-
-        # Stop the heartbeat thread.
-        stop_event.set()
-        heartbeat_thread.join()
+        try:
+            result = self.execute_tasks(tasks, log)
+        # Always stop the heartbeat thread -- even in case of an unhandled
+        # exception after running the task code, or when an unhandled
+        # BaseException is raised from within the task.
+        finally:
+            stop_event.set()
+            heartbeat_thread.join()
 
         return result


### PR DESCRIPTION
Fixes process hanging due to heartbeat thread not being stopped if a task raises `SystemExit` or something else derived from `BaseException` that isn't `JobTimeoutException`. Or if something goes wrong after task execution completed.