### PR TITLE
Remove no longer needed __future__ imports

### DIFF
--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .exceptions import (
     JobTimeoutException,
     QueueFullException,

--- a/tasktiger/flask_script.py
+++ b/tasktiger/flask_script.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import argparse
 from typing import TYPE_CHECKING, Any, List
 

--- a/tasktiger/rollbar.py
+++ b/tasktiger/rollbar.py
@@ -1,6 +1,3 @@
-# Make "import rollbar" import rollbar, and not the current module.
-from __future__ import absolute_import
-
 import json
 from typing import Any
 

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import datetime
 import importlib
 import logging

--- a/tasktiger/timeouts.py
+++ b/tasktiger/timeouts.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import signal
 from types import TracebackType
 from typing import Any, Literal, Optional, Type

--- a/tests/test_lazy_init.py
+++ b/tests/test_lazy_init.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import tempfile
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import structlog
 


### PR DESCRIPTION
I believe these are not needed in Python 3.