### PR TITLE
Add test for unhandled exception in sync worker

### DIFF
--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -35,6 +35,10 @@ def exception_task():
     raise Exception("this failed")
 
 
+def system_exit_task():
+    raise SystemExit()
+
+
 @tiger.task(queue="other")
 def task_on_other_queue():
     pass


### PR DESCRIPTION
Following up with a test here.