### PR TITLE
Tweak the docstring for the `RetryException` + better type for `original_traceback`

### DIFF
--- a/tasktiger/exceptions.py
+++ b/tasktiger/exceptions.py
@@ -31,20 +31,26 @@ class StopRetry(Exception):
 
 class RetryException(BaseException):
     """
-    Alternative to retry_on for retrying a task. If raised within a task, the
-    task will be retried as long as the retry method permits. The default retry
-    method (specified in the task or in DEFAULT_RETRY_METHOD) may be overridden
-    using the method argument. If original_traceback is True and RetryException
-    is raised from within an except block, the original traceback will be
-    logged. If log_error is set to False and the task fails permanently, a
-    warning will be logged instead of an error, and the task will be removed
-    from Redis when it completes.
+    Alternative to the `retry_on` parameter for retrying a task.
+
+    If this exception is raised within a task, the task will be retried as long
+    as the retry method permits.
+
+    The default retry method (specified in the task or in DEFAULT_RETRY_METHOD)
+    may be overridden using the method argument.
+
+    If original_traceback is True and RetryException is raised from within an
+    `except` block, the original traceback will be logged.
+
+    If `log_error` is set to False and the task fails permanently, a warning
+    will be logged instead of an error, and the task will be removed from Redis
+    when it completes.
     """
 
     def __init__(
         self,
         method: Any = None,
-        original_traceback: Any = False,
+        original_traceback: bool = False,
         log_error: bool = True,
     ):
         self.method = method


### PR DESCRIPTION
This way the docstring is more easily parseable & readable.

`original_traceback` needs to be a boolean, so the previous `Any` type annotation was unnecessarily permissive.

Note that `method` could use a better type annotation (equivalent to [`retry_method` on `delay`](https://github.com/closeio/tasktiger/blob/8c12d9001d4e079068f3e2c3664f556101b737c0/tasktiger/tasktiger.py#L444-L446)), but that can happen in a follow-up PR since I think a `NewType` or a dedicated dataclass would be preferable there.