### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release To PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      requested_release_tag:
+        description: 'The tag to use for this release (e.g., `v2.3.0`)'
+        required: true
+
+jobs:
+  build_and_upload:
+    runs-on: 'ubuntu-20.04'
+    environment: production
+    permissions:
+      # id-token for the trusted publisher setup
+      id-token: write
+      # for tagging the commit
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: 3.8
+
+      - run: |
+          pip install packaging
+      - name: Normalize the release version
+        run: |
+          echo "release_version=`echo '${{ github.event.inputs.requested_release_tag }}' | sed 's/^v//'`" >> $GITHUB_ENV
+      - name: Normalize the release tag
+        run: |
+          echo "release_tag=v${release_version}" >> $GITHUB_ENV
+      - name: Get the VERSION from setup.py
+        run: |
+          echo "package_version=`grep -Po '__version__ = "\K[^"]*' tasktiger/__init__.py`" >> $GITHUB_ENV
+      - name: Get the latest version from PyPI
+        run: |
+          curl https://pypi.org/pypi/tasktiger/json | python -c 'import json, sys; contents=sys.stdin.read(); parsed = json.loads(contents); print("pypi_version=" + parsed["info"]["version"])' >> $GITHUB_ENV
+      - name: Log all the things
+        run: |
+          echo 'Requested release tag `${{ github.event.inputs.requested_release_tag }}`'
+          echo 'Release version       `${{ env.release_version }}`'
+          echo 'Release tag           `${{ env.release_tag }}`'
+          echo 'version in package    `${{ env.package_version }}`'
+          echo 'Version in PyPI       `${{ env.pypi_version }}`'
+      - name: Verify that  the version string we produced looks like a version string
+        run: |
+          echo "${{ env.release_version }}" | sed '/^[0-9]\+\.[0-9]\+\.[0-9]\+$/!{q1}'
+      - name: Verify that the version tag we produced looks like a version tag
+        run: |
+          echo "${{ env.release_tag }}" | sed '/^v[0-9]\+\.[0-9]\+\.[0-9]\+$/!{q1}'
+      - name: Verify that the release version matches the VERSION in the package source
+        run: |
+          [[ ${{ env.release_version }} == ${{ env.package_version }} ]]
+      - name: Verify that the `release_version` is larger/newer than the existing release in PyPI
+        run: |
+          python -c 'import sys; from packaging import version; code = 0 if version.parse("${{ env.package_version }}") > version.parse("${{ env.pypi_version }}") else 1; sys.exit(code)'
+      - name: Verify that the `release_version` is present in the CHANGELOG
+        run: |
+          grep ${{ env.release_version }} CHANGELOG.md
+      - name: Serialize normalized release values as outputs
+        run: |
+          echo "release_version=$release_version"
+          echo "release_tag=$release_tag"
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+      - name: Tag commit
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.release_tag }}',
+              sha: context.sha
+            })
+      - name: Build Source Distribution
+        run: |
+          python setup.py sdist
+      - name: Upload to PyPI
+        uses: closeio/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.19.5
+
+* First version using the automated-release process
+
 ## Version 0.19.4
 
 * Log task processing in sync executor ([347](https://github.com/closeio/tasktiger/pull/347))

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
+import re
+
 from setuptools import setup
+
+VERSION_FILE = "tasktiger/__init__.py"
+with open(VERSION_FILE, encoding="utf8") as fd:
+    version = re.search(r'__version__ = ([\'"])(.*?)\1', fd.read()).group(2)
 
 with open("README.rst", encoding="utf-8") as file:
     long_description = file.read()
@@ -9,7 +15,7 @@ tests_require = install_requires + ["freezefrog", "pytest", "psutil"]
 
 setup(
     name="tasktiger",
-    version="0.19.4",
+    version=version,
     url="http://github.com/closeio/tasktiger",
     license="MIT",
     description="Python task queue",

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -12,6 +12,7 @@ from .task import Task
 from .tasktiger import TaskTiger, run_worker
 from .worker import Worker
 
+__version__ = "0.19.4"
 __all__ = [
     "TaskTiger",
     "Worker",

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -12,7 +12,7 @@ from .task import Task
 from .tasktiger import TaskTiger, run_worker
 from .worker import Worker
 
-__version__ = "0.19.4"
+__version__ = "0.19.5"
 __all__ = [
     "TaskTiger",
     "Worker",


### PR DESCRIPTION
This PR adds a manually dispatched workflow that:
* accepts a version number
* checks the version number matches `master`
* checks that there's a changelog entry for this version
* creates a tag on the current commit
* uploads the release to pypi