### PR TITLE
Prefer retry method from the task decorator if no retry method is given to RetryException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.21.0
+
+* When raising `RetryException` with no `method`, use task decorator retry method if set ([356](https://github.com/closeio/tasktiger/pull/356))
+
 ## Version 0.20.0
 
 * Add `tiger.get_sizes_for_queues_and_states` ([352](https://github.com/closeio/tasktiger/pull/352))

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -12,7 +12,7 @@ from .task import Task
 from .tasktiger import TaskTiger, run_worker
 from .worker import Worker
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 __all__ = [
     "TaskTiger",
     "Worker",

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -771,8 +771,12 @@ class Worker:
                 has_job_timeout = True
 
             if execution and execution.get("retry"):
+                # Prefer retry method from the execution, then the task, then
+                # default.
                 if "retry_method" in execution:
                     retry_func, retry_args = execution["retry_method"]
+                elif task.retry_method:
+                    retry_func, retry_args = task.retry_method
                 else:
                     # We expect the serialized method here.
                     retry_func, retry_args = serialize_retry_method(

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -135,6 +135,11 @@ def retry_task_2():
     raise RetryException(method=fixed(DELAY, 1), log_error=False)
 
 
+@tiger.task(retry_method=fixed(DELAY, 1))
+def retry_task_3():
+    raise RetryException(log_error=False)
+
+
 def verify_current_task():
     with redis.Redis(
         host=REDIS_HOST, db=TEST_DB, decode_responses=True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -39,6 +39,7 @@ from .tasks import (
     non_batch_task,
     retry_task,
     retry_task_2,
+    retry_task_3,
     simple_task,
     sleep_task,
     task_on_other_queue,
@@ -602,6 +603,23 @@ class TestCase(BaseTestCase):
 
     def test_retry_exception_2(self):
         task = self.tiger.delay(retry_task_2)
+        self._ensure_queues(queued={"default": 1})
+        assert task.n_executions() == 0
+
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues(scheduled={"default": 1})
+        assert task.n_executions() == 1
+
+        time.sleep(DELAY)
+
+        Worker(self.tiger).run(once=True)
+        Worker(self.tiger).run(once=True)
+        self._ensure_queues()
+
+        pytest.raises(TaskNotFound, task.n_executions)
+
+    def test_retry_exception_3(self):
+        task = self.tiger.delay(retry_task_3)
         self._ensure_queues(queued={"default": 1})
         assert task.n_executions() == 0
 


### PR DESCRIPTION
This matches the [already documented](https://github.com/closeio/tasktiger/commit/2d48d8e9154dd12b84580a919f5c6b3a4b9539b4) behavior.