### PR TITLE
Use OSError instead of the alias IOError or select.error

### DIFF
--- a/tasktiger/executor.py
+++ b/tasktiger/executor.py
@@ -334,16 +334,16 @@ class ForkExecutor(Executor):
                         try:
                             # Behavior of a would be blocking read()
                             # Linux:
-                            #   Python 2.7 Raises IOError
+                            #   Python 2.7 Raises OSError
                             #   Python 3.x returns empty string
                             #
                             # macOS:
                             #   Returns empty string
                             opened_fd.read(1)
-                        except IOError:
+                        except OSError:
                             pass
 
-                except select.error as e:
+                except OSError as e:
                     if e.args[0] != errno.EINTR:
                         raise
 


### PR DESCRIPTION
### What

Replace aliased usages of OSError (`IOError` and `select.error`) with OSError directly 

### Why

[PEP 3151](https://peps.python.org/pep-3151/) deprecated aliases of `OSError`.

See docs:
* [select.error](https://docs.python.org/3.13/library/select.html#select.error)
* [OSError](https://docs.python.org/3/library/exceptions.html#OSError)