### PR TITLE
Support for task workflow/dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 freezefrog==0.4.1
 psutil==5.9.8
 pytest==8.1.1
+pytz

--- a/tasktiger/_internal.py
+++ b/tasktiger/_internal.py
@@ -33,6 +33,8 @@ QUEUED = "queued"
 ACTIVE = "active"
 SCHEDULED = "scheduled"
 ERROR = "error"
+WAITING = "waiting"
+COMPLETED = "completed"
 
 # This lock is acquired in the main process when forking, and must be acquired
 # in any thread of the main process when performing an operation that triggers a

--- a/tasktiger/lua/move_task.lua
+++ b/tasktiger/lua/move_task.lua
@@ -20,7 +20,9 @@ local key_active_queue = KEYS[6]
 local key_queued_queue = KEYS[7]
 local key_error_queue = KEYS[8]
 local key_scheduled_queue = KEYS[9]
-local key_activity = KEYS[10]
+local key_waiting_queue = KEYS[10]
+local key_completed_queue = KEYS[11]
+local key_activity = KEYS[12]
 
 local id = ARGV[1]
 local queue = ARGV[2]
@@ -36,6 +38,8 @@ local state_queues_keys_by_state = {
     queued = key_queued_queue,
     error = key_error_queue,
     scheduled = key_scheduled_queue,
+    waiting = key_waiting_queue,
+    completed = key_completed_queue,
 }
 local key_from_state_queue = state_queues_keys_by_state[from_state]
 local key_to_state_queue = state_queues_keys_by_state[to_state]

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
 from redis import Redis
 
-from ._internal import ACTIVE, ERROR, QUEUED, SCHEDULED
+from ._internal import ACTIVE, ERROR, QUEUED, SCHEDULED, WAITING, COMPLETED
 
 try:
     from redis.commands.core import Script
@@ -634,6 +634,8 @@ class RedisScripts:
         key_queued_queue = key_func(QUEUED, queue)
         key_error_queue = key_func(ERROR, queue)
         key_scheduled_queue = key_func(SCHEDULED, queue)
+        key_waiting_queue = key_func(WAITING, queue)
+        key_completed_queue = key_func(COMPLETED, queue)
         key_activity = key_func("activity")
 
         return self._move_task(
@@ -647,6 +649,8 @@ class RedisScripts:
                 key_queued_queue,
                 key_error_queue,
                 key_scheduled_queue,
+                key_waiting_queue,
+                key_completed_queue,
                 key_activity,
             ],
             args=[

--- a/tasktiger/task.py
+++ b/tasktiger/task.py
@@ -19,9 +19,12 @@ import redis
 from structlog.stdlib import BoundLogger
 
 from ._internal import (
+    ACTIVE,
     ERROR,
     QUEUED,
     SCHEDULED,
+    WAITING,
+    COMPLETED,
     g,
     gen_id,
     gen_unique_id,
@@ -53,6 +56,7 @@ class Task:
         unique_key: Optional[Collection[str]] = None,
         lock: Optional[bool] = None,
         lock_key: Optional[Collection[str]] = None,
+        depends: Optional[Union[str, Collection[str]]] = None,
         retry: Optional[bool] = None,
         retry_on: Optional[Collection[Type[BaseException]]] = None,
         retry_method: Optional[
@@ -140,6 +144,8 @@ class Task:
             task["unique"] = True
             if unique_key:
                 task["unique_key"] = unique_key
+        if depends:
+            task["depends"] = depends
         if lock or lock_key:
             task["lock"] = True
             if lock_key:
@@ -211,6 +217,10 @@ class Task:
     @property
     def lock(self) -> bool:
         return self._data.get("lock", False)
+
+    @property
+    def depends(self) -> List[str]:
+        return self._data.get("depends", None)
 
     @property
     def lock_key(self) -> Optional[str]:
@@ -495,6 +505,48 @@ class Task:
         else:
             raise TaskNotFound("Task {} not found.".format(task_id))
 
+    def get_dependencies(self, states: Optional[List[str]] = None) -> List["Task"]:
+        """
+        Get the dependency tasks, use the states param to filter which states to search.
+        Use only for reporting!
+        """
+        tasks: List[Task] = []
+        if not self.depends:
+            return tasks
+        if not states:
+            states = [QUEUED, ACTIVE, SCHEDULED, ERROR, WAITING, COMPLETED]
+        for dep_task_id in self.depends:
+            dep_task = None
+            for state in states:
+                try:
+                    dep_task = self._get_dependency(state, self.queue, dep_task_id)
+                    if dep_task:
+                        break
+                except Exception:
+                    pass
+            if dep_task:
+                tasks.append(dep_task)
+            else:
+                tasks.append(Task(self.tiger, queue="Not Found", _data={"id": dep_task_id}))
+        return tasks
+
+    def _get_dependency(
+        self, state: str, queue: str, task_id: str
+    ) -> Union["Task", None]:
+        """
+        Get the dependency task for the queue if it exists to avoid raising exceptions.
+        """
+        exists = self.tiger.connection.zscore(self.tiger._key(state, queue), task_id)
+        if exists:
+            dep_task = Task.from_id(
+                tiger=self.tiger,
+                queue=queue,
+                state=state,
+                task_id=task_id,
+            )
+            return dep_task
+        return None
+
     @classmethod
     def tasks_from_queue(
         cls,
@@ -621,12 +673,15 @@ class Task:
 
     def delete(self) -> None:
         """
-        Removes a task that's in the error queue.
+        Removes a task that's in the error or completed queue.
 
-        Raises TaskNotFound if the task could not be found in the ERROR
-        queue.
+        Raises TaskNotFound if the task could not be found
+        in the COMPLETED or ERROR queue.
         """
-        self._move(from_state=ERROR)
+        if self.state == COMPLETED:
+            self._move(from_state=COMPLETED)
+        else:
+            self._move(from_state=ERROR)
 
     def clone(self) -> "Task":
         """Returns a clone of the this task"""

--- a/tasktiger/tasktiger.py
+++ b/tasktiger/tasktiger.py
@@ -1,6 +1,10 @@
 import datetime
 import importlib
 import logging
+import sys
+import os
+import signal
+import time
 from collections import defaultdict
 from typing import (
     Any,
@@ -25,6 +29,8 @@ from ._internal import (
     ERROR,
     QUEUED,
     SCHEDULED,
+    WAITING,
+    COMPLETED,
     classproperty,
     g,
     queue_matches,
@@ -395,6 +401,7 @@ class TaskTiger:
         module: Optional[str] = None,
         exclude_queues: Optional[str] = None,
         max_workers_per_queue: Optional[int] = None,
+        max_parallel_workers: Optional[int] = None,
         store_tracebacks: Optional[bool] = None,
         executor_class: Optional[Type[Executor]] = None,
         exit_after: Optional[datetime.timedelta] = None,
@@ -405,7 +412,67 @@ class TaskTiger:
         The arguments are explained in the module-level run_worker() method's
         click options.
         """
+        
+        if max_parallel_workers is None or max_parallel_workers <= 0:
+            max_parallel_workers = 1
 
+        # when run parallel workers we ignore ctrl-c for the main process 
+        # since the children workers will handle the signal and finish gracefully
+        if max_parallel_workers > 0:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+        worker_pids: set[int] = set()
+        for _ in range(max_parallel_workers):
+            pid = os.getpid()
+            if max_parallel_workers > 1:
+                pid = os.fork()
+                if pid != 0:
+                    worker_pids.add(pid)
+                    continue
+
+            self._start_worker(
+                queues,
+                module,
+                exclude_queues,
+                max_workers_per_queue,
+                store_tracebacks,
+                executor_class,
+                exit_after,
+            )
+
+            if pid == 0:
+                # for children we clear the inherited values from the parent
+                worker_pids.clear()
+                max_parallel_workers = 1
+                break
+
+        # wait for children to finish
+        while len(worker_pids) > 0:
+            time.sleep(1)
+            try:
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+                if pid != 0:
+                    worker_pids.remove(pid)
+            except ChildProcessError as ex:
+                if ex.errno == 10:  # no more children
+                    worker_pids.clear()
+            except Exception as ex:
+                print(ex, type(ex), file=sys.stderr)
+
+    def _start_worker(
+        self,
+        queues: Optional[str] = None,
+        module: Optional[str] = None,
+        exclude_queues: Optional[str] = None,
+        max_workers_per_queue: Optional[int] = None,
+        store_tracebacks: Optional[bool] = None,
+        executor_class: Optional[Type[Executor]] = None,
+        exit_after: Optional[datetime.timedelta] = None,
+    ) -> None:
+        """
+        Start worker
+        """
         try:
             module_names = module or ""
             for module_name in module_names.split(","):
@@ -439,6 +506,7 @@ class TaskTiger:
         lock: Optional[bool] = None,
         lock_key: Optional[Collection[str]] = None,
         when: Optional[Union[datetime.datetime, datetime.timedelta]] = None,
+        depends: Optional[Union[str, Collection[str]]] = None,
         retry: Optional[bool] = None,
         retry_on: Optional[Collection[Type[BaseException]]] = None,
         retry_method: Optional[
@@ -463,6 +531,7 @@ class TaskTiger:
             unique_key=unique_key,
             lock=lock,
             lock_key=lock_key,
+            depends=depends,
             retry=retry,
             retry_on=retry_on,
             retry_method=retry_method,
@@ -479,7 +548,7 @@ class TaskTiger:
         Get the queue's number of tasks in each state.
 
         Returns dict with queue size for the QUEUED, SCHEDULED, and ACTIVE
-        states. Does not include size of error queue.
+        states. Does not include size of error queue nor completed queue.
         """
 
         states = [QUEUED, SCHEDULED, ACTIVE]
@@ -541,13 +610,13 @@ class TaskTiger:
         """
         Returns a dict with stats about all the queues. The keys are the queue
         names, the values are dicts representing how many tasks are in a given
-        status ("queued", "active", "error" or "scheduled").
+        status ("queued", "active", "error", "waiting", "completed" or "scheduled").
 
         Example return value:
         { "default": { "queued": 1, "error": 2 } }
         """
 
-        states = (QUEUED, ACTIVE, SCHEDULED, ERROR)
+        states = (QUEUED, ACTIVE, SCHEDULED, ERROR, WAITING, COMPLETED)
 
         pipeline = self.connection.pipeline()
         for state in states:
@@ -700,6 +769,12 @@ class TaskTiger:
     type=int,
 )
 @click.option(
+    "-P",
+    "--max-parallel-workers",
+    help="Maximum parallel workers",
+    type=int,
+)
+@click.option(
     "--store-tracebacks/--no-store-tracebacks",
     help="Store tracebacks with execution history",
     default=None,
@@ -728,6 +803,7 @@ def run_worker(
     module: Optional[str] = None,
     exclude_queues: Optional[str] = None,
     max_workers_per_queue: Optional[int] = None,
+    max_parallel_workers: Optional[int] = None,
     store_tracebacks: Optional[bool] = None,
     executor: Optional[str] = "fork",
     exit_after: Optional[int] = None,
@@ -755,6 +831,7 @@ def run_worker(
         module=module,
         exclude_queues=exclude_queues,
         max_workers_per_queue=max_workers_per_queue,
+        max_parallel_workers=max_parallel_workers,
         store_tracebacks=store_tracebacks,
         executor_class=executor_class,
         exit_after=exit_after_td,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -31,6 +31,8 @@ from ._internal import (
     ERROR,
     QUEUED,
     SCHEDULED,
+    WAITING,
+    COMPLETED,
     dotted_parts,
     gen_unique_id,
     import_attribute,
@@ -665,6 +667,19 @@ class Worker:
                     lock_ids.add(lock_id)
                     locks.append(lock)
 
+            # if dependent tasks are not completed we move to waiting state
+            if not self.are_deps_completed(task):
+                task._move(
+                    from_state=ACTIVE,
+                    to_state=WAITING,
+                )
+                log.debug(
+                    "dependencies pending",
+                    src_queue=ACTIVE,
+                    dest_queue=WAITING,
+                    task_id=task.id,
+                )
+                continue
             ready_tasks.append(task)
 
         if not ready_tasks:
@@ -686,6 +701,20 @@ class Worker:
                 log.warning("could not release lock", lock=lock.name)
 
         return success, ready_tasks
+
+    def are_deps_completed(self, task: Task) -> bool:
+        """
+        True if all depend tasks are completed
+        """
+
+        if not task.depends:
+            return True
+
+        for dep_task_id in task.depends:
+            exists = self.tiger.connection.zscore(self.tiger._key(COMPLETED, task.queue), dep_task_id)
+            if not exists:
+                return False
+        return True
 
     def _finish_task_processing(
         self, queue: str, task: Task, success: bool, start_time: float
@@ -712,11 +741,39 @@ class Worker:
 
         def _mark_done() -> None:
             # Remove the task from active queue
-            task._move(from_state=ACTIVE)
+            task._move(from_state=ACTIVE, to_state=COMPLETED)
             log.info("done", **log_context)
+
+        def _sched_dependents() -> None:
+            # Schedule tasks that were dependent on this task
+            # TODO: use a reverse lookup instead of this nested loop
+            dependent_tasks_ids = self.connection.zrange(
+                self._key(WAITING, task.queue), 0, -1
+            )
+            for dependent_task_id in dependent_tasks_ids:
+                dependent_task = Task.from_id(
+                    self.tiger,
+                    queue=task.queue,
+                    state=WAITING,
+                    task_id=dependent_task_id,
+                )
+                if not dependent_task.depends:
+                    continue
+                for dep_task_id in dependent_task.depends:
+                    if dep_task_id == task.id:
+                        dependent_task._move(from_state=WAITING, to_state=SCHEDULED)
+                        log.debug(
+                            "dependency completed",
+                            src_queue=WAITING,
+                            dest_queue=SCHEDULED,
+                            task_id=task.id,
+                            dep_task_id=dep_task_id,
+                        )
+                        break
 
         if success:
             _mark_done()
+            _sched_dependents()
         else:
             should_retry = False
             should_log_error = True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -94,7 +94,7 @@ class TestCase(BaseTestCase):
 
         Worker(self.tiger).run(once=True)
         self._ensure_queues(queued={"default": 0})
-        assert not self.conn.exists("t:task:%s" % task["id"])
+        assert self.conn.zscore("t:completed:default", task["id"])
 
     @pytest.mark.skipif(sys.version_info < (3, 3), reason="__qualname__ unavailable")
     def test_staticmethod_task(self):
@@ -105,7 +105,7 @@ class TestCase(BaseTestCase):
 
         Worker(self.tiger).run(once=True)
         self._ensure_queues(queued={"default": 0})
-        assert not self.conn.exists("t:task:%s" % task["id"])
+        assert self.conn.zscore("t:completed:default", task["id"])
 
     def test_task_delay(self):
         decorated_task.delay(1, 2, a=3, b=4)
@@ -602,8 +602,6 @@ class TestCase(BaseTestCase):
         Worker(self.tiger).run(once=True)
         self._ensure_queues()
 
-        pytest.raises(TaskNotFound, task.n_executions)
-
     def test_retry_exception_3(self):
         task = self.tiger.delay(retry_task_3)
         self._ensure_queues(queued={"default": 1})
@@ -618,8 +616,6 @@ class TestCase(BaseTestCase):
         Worker(self.tiger).run(once=True)
         Worker(self.tiger).run(once=True)
         self._ensure_queues()
-
-        pytest.raises(TaskNotFound, task.n_executions)
 
     @pytest.mark.parametrize("count", [1, 3, 7])
     def test_retry_executions_count(self, count):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -53,7 +53,7 @@ class TestLogging(BaseTestCase):
 
         Worker(self.tiger).run(once=True)
         self._ensure_queues(queued={"foo_qux": 0})
-        assert not self.conn.exists("t:task:%s" % task["id"])
+        assert self.conn.zscore("t:completed:foo_qux", task["id"])
 
 
 class TestSetupStructlog(BaseTestCase):

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -310,7 +310,7 @@ class TestPeriodicTasks(BaseTestCase):
 
         # Ensure we cleared any previous executions.
         task = Task.from_id(tiger, "periodic", SCHEDULED, task_id, load_executions=10)
-        assert len(task.executions) == 0
+        assert len(task.executions) == 1
 
     def test_successful_execution_doesnt_clear_previous_errors(self):
         """

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -23,7 +23,7 @@ from .tasks import (
     wait_for_long_task,
 )
 from .test_base import BaseTestCase
-from .utils import external_worker
+from .utils import external_parallel_worker, external_worker
 
 
 class TestMaxWorkers(BaseTestCase):
@@ -258,3 +258,33 @@ class TestSyncExecutorWorker:
         # handled by the executor, the task is still active until it times out
         # and gets requeued by another worker.
         ensure_queues(active={"default": 1})
+
+
+class TestMaxParallelWorkers(BaseTestCase):
+    """Max Parallel Worker Queue tests."""
+
+    def test_max_parallel_workers(self):
+        """Test Parallel Worker Queue."""
+
+        # Queue three tasks
+        for i in range(0, 3):
+            task = Task(self.tiger, long_task_ok, queue="a")
+            task.delay()
+        self._ensure_queues(queued={"a": 3})
+        # self._ensure_queues()
+
+        # # Start two parallel workers and wait until they start processing.
+        worker = Process(
+            target=external_parallel_worker,
+            kwargs={
+                "worker_kwargs": {"queues": "a", "max_parallel_workers": 2},
+            },
+        )
+        worker.start()
+
+        # Wait for both tasks to start
+        wait_for_long_task()
+        wait_for_long_task()
+
+        # Verify that 2 of them are active
+        self._ensure_queues(active={"a": 2}, queued={"a": 1})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,6 +87,22 @@ def external_worker(n=None, patch_config=None, worker_kwargs=None):
     tiger.connection.close()
 
 
+def external_parallel_worker(n=None, patch_config=None, worker_kwargs=None):
+    """
+    Runs a worker. To be used with multiprocessing.Pool.map.
+    """
+    tiger = get_tiger()
+
+    if patch_config:
+        tiger.config.update(patch_config)
+
+    if worker_kwargs is None:
+        worker_kwargs = {}
+
+    tiger.run_worker(**worker_kwargs)
+
+    tiger.connection.close()
+
 def sleep_until_next_second():
     now = datetime.datetime.utcnow()
     time.sleep(1 - now.microsecond / 10.0**6)


### PR DESCRIPTION
I'm planning on using tasktiger as a light-weight CI workflow scheduler. These are the basic changes that support this concept if you're interested.

Changes:
* New optional parameter `depends` for class `Task` that will be used to assign a list of task ids as dependencies.
* 2 new states: `WAITING` and `COMPLETED`.
* When a task is moved to `ACTIVE` state and dependencies have not completed it will move to the `WAITING` state.
* When a task is completed it will move any tasks that are dependent from `WAITING` to `SCHEDULED` state.
* NOTE: All tasks after completion will remain in `COMPLETED` state instead of removing from db!
* New optional parameter `max_parallel_workers` for `TaskTiger.run_worker()` and command line option `-P --max-parallel-workers`. This is a simple wrapper that will fork multiple workers for user convenience.
* Tests cases are updated, I had to add pytz to the requirements file to make it work with github ci.

This is based on a squash merge from my fork.
I'll also be creating a PR with the tasktiger-admin changes for supporting these changes.
