### PR TITLE
fix redis-py install constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.25.1
+
+* Fixed: Widened `redis` dependency from `>=3.3.0,<5` to `>=4.0,<7` to match the CI-tested redis-py matrix (4.6.0, 6.1.0). The previous `<5` cap prevented co-installation with redis-py 5.x and 6.x.
+
 ## Version 0.25.0
 
 * Added `Task.scheduled_at` property signifying when the task is/was supposed to run.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(VERSION_FILE, encoding="utf8") as fd:
 with open("README.rst", encoding="utf-8") as file:
     long_description = file.read()
 
-install_requires = ["click", "redis>=3.3.0,<5", "structlog"]
+install_requires = ["click", "redis>=4.0,<7", "structlog"]
 
 tests_require = install_requires + ["freezefrog", "pytest", "psutil"]
 

--- a/tasktiger/__init__.py
+++ b/tasktiger/__init__.py
@@ -12,7 +12,7 @@ from .task import Task
 from .tasktiger import TaskTiger, run_worker
 from .worker import Worker
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"
 __all__ = [
     "TaskTiger",
     "Worker",


### PR DESCRIPTION
## Summary

`setup.py` caps `redis<5`, blocking redis-py 4.6.0 and 6.1.0 (both in CI) and any downstream using `redis>=5`.

**Fix:** widen to `redis>=4.0,<7`. Bump version to `0.25.1`. Add CHANGELOG entry. No runtime changes.

## Bug Repro

```bash
pip install tasktiger==0.25.0 redis==6.1.0
# ERROR: ResolutionImpossible
```

`<5` cap forbids 6.1.0 — same version `requirements.txt` pins and CI tests.