### PR TITLE
Make expired-task cleanup atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* `Worker._worker_queue_expired_tasks` now cleans up orphaned ACTIVE entries in a single `EVAL` Lua script, instead of a non-atomic `GET` + `_move()`. Removes a rare edge-case race condition in the missing-data-hash flow that the original author flagged with `# XXX: should be atomic`. Possibly related to [#113](https://github.com/closeio/tasktiger/issues/113)
+
 ## Version 0.25.0
 
 * Added `Task.scheduled_at` property signifying when the task is/was supposed to run.

--- a/tasktiger/redis_scripts.py
+++ b/tasktiger/redis_scripts.py
@@ -276,6 +276,19 @@ UPDATE_SCHEDULED_TIME = """
     end
 """
 
+# KEYS = { task_data_key, from_state_queue_zset, from_state_set }
+# ARGV = { task_id, queue }
+HANDLE_EXPIRED_TASK = """
+    if redis.call('get', KEYS[1]) then
+        return 0
+    end
+    redis.call('zrem', KEYS[2], ARGV[1])
+    if redis.call('zcard', KEYS[2]) == 0 then
+        redis.call('srem', KEYS[3], ARGV[2])
+    end
+    return 1
+"""
+
 # KEYS = { }
 # ARGV = { key_prefix, time, batch_size }
 GET_EXPIRED_TASKS = """
@@ -338,6 +351,8 @@ class RedisScripts:
         self._get_expired_tasks = redis.register_script(GET_EXPIRED_TASKS)
 
         self._update_scheduled_time = redis.register_script(UPDATE_SCHEDULED_TIME)
+
+        self._handle_expired_task = redis.register_script(HANDLE_EXPIRED_TASK)
 
         self._move_task = self.register_script_from_file(
             "lua/move_task.lua",
@@ -601,6 +616,36 @@ class RedisScripts:
             args=[score, member],
         )
         return bool(result)
+
+    def handle_expired_task(
+        self,
+        key_task: str,
+        key_from_state_queue: str,
+        key_from_state: str,
+        id: str,
+        queue: str,
+        client: Optional[Redis] = None,
+    ) -> int:
+        """
+        Cleans up an expired-task ZSET entry whose task-data hash is
+        missing. The check-and-cleanup runs in a single EVAL so the
+        hash check and the ZREM cannot be corrupted with
+        another client's writes. If the hash is re-materialized
+        between the ``get_expired_tasks`` scan and this call, the
+        script does nothing and the next expiry pass re-evaluates.
+
+        Returns 1 if the entry was cleaned up, 0 if the hash came
+        back and no state was modified.
+
+        Replaces the non-atomic ``GET`` + ``_move()`` pair the
+        original author flagged with ``# XXX: should be atomic``; see
+        the discussion on #113.
+        """
+        return self._handle_expired_task(
+            keys=[key_task, key_from_state_queue, key_from_state],
+            args=[id, queue],
+            client=client,
+        )
 
     def move_task(
         self,

--- a/tasktiger/worker.py
+++ b/tasktiger/worker.py
@@ -330,17 +330,15 @@ class Worker:
             except TaskNotFound:
                 # Either the task was requeued by another worker, or we
                 # have a task without a task object.
-
-                # XXX: Ideally, the following block should be atomic.
-                if not self.connection.get(self._key("task", task_id)):
+                result = self.scripts.handle_expired_task(
+                    key_task=self._key("task", task_id),
+                    key_from_state_queue=self._key(ACTIVE, queue),
+                    key_from_state=self._key(ACTIVE),
+                    id=task_id,
+                    queue=queue,
+                )
+                if result == 1:
                     self.log.error("not found", queue=queue, task_id=task_id)
-                    task = Task(
-                        self.tiger,
-                        queue=queue,
-                        _data={"id": task_id},
-                        _state=ACTIVE,
-                    )
-                    task._move()
 
         # Release the lock immediately if we processed a full batch. This way,
         # another process will be able to pick up another batch immediately

--- a/tests/test_worker_atomicity.py
+++ b/tests/test_worker_atomicity.py
@@ -1,0 +1,112 @@
+"""Tests for the atomic expired-task cleanup in Worker._worker_queue_expired_tasks."""
+
+import json
+import os
+import signal
+import time
+from multiprocessing import Process
+
+from tasktiger import Task, Worker
+from tasktiger._internal import ACTIVE
+
+from .config import DELAY
+from .tasks import sleep_task
+from .utils import external_worker
+
+
+def test_expiry_cleans_up_orphan_active_entry(tiger):
+    """A worker is killed mid-task with its data already
+    evicted from Redis. The next expiry pass should remove the orphan
+    from the active queue."""
+    redis = tiger.connection
+    prefix = tiger.config["REDIS_PREFIX"]
+    queue = "default"
+    active_zset = f"{prefix}:{ACTIVE}:{queue}"
+
+    task = Task(tiger, sleep_task, kwargs={"delay": 2 * DELAY})
+    task.delay()
+
+    worker_proc = Process(target=external_worker)
+    worker_proc.start()
+    time.sleep(DELAY)  # allow the worker to move the task to ACTIVE
+
+    # Simulate an eviction
+    assert redis.delete(f"{prefix}:task:{task.id}") == 1
+    os.kill(worker_proc.pid, signal.SIGKILL)
+    worker_proc.join(timeout=5)
+
+    assert redis.zscore(active_zset, task.id) is not None
+    assert redis.exists(f"{prefix}:task:{task.id}") == 0
+
+    time.sleep(2 * DELAY)
+    Worker(tiger).run(once=True, force_once=True)
+    Worker(tiger).run(once=True, force_once=True)
+
+    assert redis.zscore(active_zset, task.id) is None, (
+        f"expiry failed to remove orphan ACTIVE entry for {task.id!r}"
+    )
+    assert redis.scard(f"{prefix}:{ACTIVE}") == 0
+
+
+def test_handle_expired_task_lua_atomicity(tiger):
+    """Test the HANDLE_EXPIRED_TASK Lua script cases:
+    - the task data still exists (do nothing)
+    - the data is gone but other tasks share the queue
+    - the data is gone and there are no other tasks in the queue"""
+    redis = tiger.connection
+    prefix = tiger.config["REDIS_PREFIX"]
+    queue = "default"
+    task_key = f"{prefix}:task:t1"
+    zset_key = f"{prefix}:{ACTIVE}:{queue}"
+    state_key = f"{prefix}:{ACTIVE}"
+
+    # task data still exists, do nothing
+    redis.flushdb()
+    redis.set(task_key, json.dumps({"id": "t1"}))
+    redis.zadd(zset_key, {"t1": 1.0})
+    redis.sadd(state_key, queue)
+
+    result = tiger.scripts.handle_expired_task(
+        key_task=task_key,
+        key_from_state_queue=zset_key,
+        key_from_state=state_key,
+        id="t1",
+        queue=queue,
+    )
+    assert result == 0
+    assert redis.exists(task_key) == 1
+    assert redis.zscore(zset_key, "t1") == 1.0
+    assert redis.sismember(state_key, queue) == 1
+
+    # data removed, another task shares the queue, queue tracker stays.
+    redis.flushdb()
+    redis.zadd(zset_key, {"t1": 1.0, "other": 2.0})
+    redis.sadd(state_key, queue)
+
+    result = tiger.scripts.handle_expired_task(
+        key_task=task_key,
+        key_from_state_queue=zset_key,
+        key_from_state=state_key,
+        id="t1",
+        queue=queue,
+    )
+    assert result == 1
+    assert redis.zscore(zset_key, "t1") is None
+    assert redis.zscore(zset_key, "other") == 2.0
+    assert redis.sismember(state_key, queue) == 1
+
+    # data removed, no other tasks in the queue, tracker removed.
+    redis.flushdb()
+    redis.zadd(zset_key, {"t1": 1.0})
+    redis.sadd(state_key, queue)
+
+    result = tiger.scripts.handle_expired_task(
+        key_task=task_key,
+        key_from_state_queue=zset_key,
+        key_from_state=state_key,
+        id="t1",
+        queue=queue,
+    )
+    assert result == 1
+    assert redis.zscore(zset_key, "t1") is None
+    assert redis.sismember(state_key, queue) == 0


### PR DESCRIPTION
## Summary

Replace `GET` + `_move()` in `Worker._worker_queue_expired_tasks` with single Lua `EVAL` (`HANDLE_EXPIRED_TASK`).

Closes race window flagged by `# XXX: Ideally, the following block should be atomic.`

## Notes

No regression test — race window not reliably reproducible on master. Happy to dig deeper if required before merge.