### PR TITLE
fix: add pip --user bin dir to PATH so documented test command works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12
+ENV PATH="/root/.local/bin:${PATH}"
 
 WORKDIR /src
 COPY requirements.txt .


### PR DESCRIPTION
Went to run the test suite to find somewhere to contribute and hit this first:

docker-compose run --rm tasktiger pytest → exec: "pytest": executable file not found in $PATH

The Dockerfile installs with pip install --user, so console scripts land in /root/.local/bin, which isn't on PATH. pip actually warns about it during the build. Adding the dir to PATH makes the documented command work.

python -m pytest works fine, which is presumably why nobody's hit it, along with CI running through Actions rather than compose.

Verified after the change: 184 passed.